### PR TITLE
Add documentation link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Corey Farwell <coreyf@rwell.org>"]
 keywords = ["packaging", "index", "dependencies", "crate", "meta"]
 repository = "https://github.com/frewsxcv/rust-crates-index"
 license = "Apache-2.0"
+documentation = "https://frewsxcv.github.io/rust-crates-index/crates_index/index.html"
 
 [dependencies]
 git2 = "0.2.11"


### PR DESCRIPTION
Currently, on the crates.io page, there is only a link to this repository page. This commit/pr will add a link to the documentation so that users can find it straight from the crates.io page.