### PR TITLE
Update git2 dependency and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crates-index"
 description = "Library for retrieving and interacting with the crates.io index"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 keywords = ["packaging", "index", "dependencies", "crate", "meta"]
 repository = "https://github.com/frewsxcv/rust-crates-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ license = "Apache-2.0"
 documentation = "https://frewsxcv.github.io/rust-crates-index/crates_index/index.html"
 
 [dependencies]
-git2 = "0.2.11"
+git2 = "0.3.3"
 glob = "0.2.10"
 rustc-serialize = "0.3.14"


### PR DESCRIPTION
This crate won't even build today, given that the dependencies now produce a divergent requirement on `libz`:

```
native library `z` is being linked to by more than one package, and can only be linked to by one package

  libz-sys v0.1.9
  libz-sys v1.0.0
```

Updating git2 fixes this.

I also included a commit to release a new version with this update, that'd be great if you could :)