### PR TITLE
Some small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ rust:
   - beta
   # check it compiles on the latest stable compiler
   - stable
-  # and the first stable one (this should be bumped as the minimum
-  # Rust version required changes)
-  - 1.0.0
 
 # load travis-cargo
 before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ license = "Apache-2.0"
 documentation = "https://frewsxcv.github.io/rust-crates-index/crates_index/index.html"
 
 [dependencies]
-git2 = "0.3.3"
+git2 = "0.5.1"
 glob = "0.2.10"
 rustc-serialize = "0.3.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crates-index"
 description = "Library for retrieving and interacting with the crates.io index"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 keywords = ["packaging", "index", "dependencies", "crate", "meta"]
 repository = "https://github.com/frewsxcv/rust-crates-index"


### PR DESCRIPTION
1. update the git2 version so conflicts with openssl-sys don't happen
2. add generated directory to .gitignore
3. bump version

If you could publish this to crates.io too, that'd be great :heart: 