### PR TITLE
Updated `PathBuf` types to `AsRef<Path>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,9 +135,10 @@ impl Iterator for Crates {
 pub struct CrateIndexPaths(std::iter::Chain<glob::Paths, glob::Paths>);
 
 impl CrateIndexPaths {
-    fn new(path: PathBuf) -> CrateIndexPaths {
+    fn new<P: AsRef<Path>>(path: P) -> CrateIndexPaths {
         let mut match_options = glob::MatchOptions::new();
         match_options.require_literal_leading_dot = true;
+        let path = path.as_ref();
 
         let glob_pattern = format!("{}/*/*/*", path.to_str().unwrap());
         let index_paths1 = glob::glob_with(&glob_pattern, &match_options).unwrap();
@@ -164,8 +165,9 @@ pub struct Index {
 
 impl Index {
     /// Construct a new Index supplying a path where the index lives or should live
-    pub fn new(path: PathBuf) -> Index {
-        Index{path: path}
+    pub fn new<P: AsRef<Path>>(path: P) -> Index {
+        let pathbuf = path.as_ref().to_path_buf();
+        Index{path: pathbuf}
     }
 
     /// Determines if *anything* exists at the path specified from the constructor
@@ -207,7 +209,8 @@ pub struct Crate {
 }
 
 impl Crate {
-    pub fn new(index_path: &Path) -> Crate {
+    pub fn new<P: AsRef<Path>>(index_path: P) -> Crate {
+        let index_path = index_path.as_ref();
         let mut versions = vec![];
         let file = fs::File::open(&index_path).unwrap();
         for line in BufReader::new(file).lines() {
@@ -234,7 +237,7 @@ impl Crate {
 
 #[test]
 fn test_dependencies() {
-    let index = Index::new("_test".into());
+    let index = Index::new("_test");
     if !index.exists() {
         index.clone().unwrap();
     }


### PR DESCRIPTION
This lets you use any type that implements `AsRef<Path>` to specify
a path, namely `PathBuf`, `String` and `str`.  So you can just pass
a string into the functions that want a path instead of having to
call `.into()` or such on it.