### PR TITLE
Fix some clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ error_chain! {
     }
 }
 
-static INDEX_GIT_URL: &'static str = "https://github.com/rust-lang/crates.io-index";
+static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
 
 /// A single version of a crate published to the index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ impl Crate {
         if versions.is_empty() {
             return Err(io::Error::new(io::ErrorKind::Other, "crate must have versions"));
         }
-        Ok(Crate { versions: versions })
+        Ok(Crate { versions })
     }
 
     /// Published versions of this crate sorted chronologically by date published

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,24 +138,15 @@ impl Dependency {
     }
 
     pub fn target(&self) -> Option<&str> {
-        match self.target {
-            Some(ref s) => Some(s),
-            None => None,
-        }
+        self.target.as_deref()
     }
 
     pub fn kind(&self) -> Option<&str> {
-        match self.kind {
-            Some(ref s) => Some(s),
-            None => None,
-        }
+        self.kind.as_deref()
     }
 
     pub fn package(&self) -> Option<&str> {
-        match self.package {
-            Some(ref s) => Some(s),
-            None => None,
-        }
+        self.package.as_deref()
     }
 
     /// Returns the name of the crate providing the dependency.


### PR DESCRIPTION
* Use shorthand struct initialization syntax
* Remove redundant `'static`
* Simplify getters by using `Option::as_deref()`

`Option::as_deref()` became stable fairly recently, in Rust v1.40.