### PR TITLE
Breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crates-index"
 description = "Library for retrieving and interacting with the crates.io index"
-version = "0.14.5"
+version = "0.15.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 keywords = ["packaging", "index", "dependencies", "crate", "meta"]
 categories = ["development-tools", "database"]
@@ -16,7 +16,6 @@ glob = "0.3.0"
 serde_derive = "1.0.105"
 serde_json = "1.0.48"
 serde = "1.0.105"
-error-chain = "0.12.2"
 home = "0.5.3"
 smol_str = { version = "0.1.15", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.48"
 serde = "1.0.105"
 home = "0.5.3"
 smol_str = { version = "0.1.15", features = ["serde"] }
+hex = { version = "0.4.2", features = ["serde"] }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub struct Version {
     name: SmolStr,
     vers: SmolStr,
     deps: Box<[Dependency]>,
-    cksum: Box<str>,
+    #[serde(with = "hex")]
+    cksum: [u8; 32],
     features: HashMap<String, Vec<String>>,
     yanked: bool,
 }
@@ -77,8 +78,10 @@ impl Version {
     }
 
     /// Checksum of the package for this version
+    ///
+    /// SHA256 of the .crate file
     #[inline]
-    pub fn checksum(&self) -> &str {
+    pub fn checksum(&self) -> &[u8; 32] {
         &self.cksum
     }
 


### PR DESCRIPTION
* Error-chain is an overkill for 1 error case

* `Crate::new` should be fallible

* Checksum can take 32 bytes instead of 80+

* Dependency kind doesn't need to be a string. It's parsed as an option to make serde happy, but the default is "normal", so the API can just return the default instead of `None`.
