### PR TITLE
add `latest_semver_version` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [dependencies]
 git2 = "0.13.0"
 glob = "0.3.0"
+semver = "0.10.0"
 serde_derive = "1.0.105"
 serde_json = "1.0.48"
 serde = "1.0.105"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,6 +432,7 @@ impl Crate {
 
     /// Returns the highest version as per semantic release specification,
     /// filtering out versions with pre-release identifiers.
+    #[inline]
     pub fn highest_stable_version(&self) -> Option<SemverVersion> {
         self.versions.iter()
             .map(|v| SemverVersion::parse(&v.vers).ok())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,16 +418,21 @@ impl Crate {
     }
 
     #[inline]
-    pub fn latest_semver_version(&self) -> Option<SemverVersion> {
+    pub fn highest_version(&self) -> SemverVersion {
         self.versions.iter()
             .map(|v| SemverVersion::parse(&v.vers).ok())
             .flatten()
             .max()
+            // Safety: Versions inside the index will always adhere to semantic versioning. If a crate is inside the index, at least one version is inside of it.
+            .unwrap()
     }
 
-    #[inline]
-    pub fn latest_semver_version_unchecked(&self) -> SemverVersion {
-        self.latest_semver_version().unwrap()
+    pub fn highest_stable_version(&self) -> Option<SemverVersion> {
+        self.versions.iter()
+            .map(|v| SemverVersion::parse(&v.vers).ok())
+            .flatten()
+            .filter(|v| !v.is_prerelease())
+            .max()
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! }
 //! ```
 
+use semver::Version as SemverVersion;
 use serde_derive::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::HashMap;
@@ -414,6 +415,19 @@ impl Crate {
     #[inline]
     pub fn latest_version(&self) -> &Version {
         &self.versions[self.versions.len() - 1]
+    }
+
+    #[inline]
+    pub fn latest_semver_version(&self) -> Option<SemverVersion> {
+        self.versions.iter()
+            .map(|v| SemverVersion::parse(&v.vers).ok())
+            .flatten()
+            .max()
+    }
+
+    #[inline]
+    pub fn latest_semver_version_unchecked(&self) -> SemverVersion {
+        self.latest_semver_version().unwrap()
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ impl Crate {
         &self.versions[self.versions.len() - 1]
     }
 
-    /// Returns the highest version as per semantic release specification.
+    /// Returns the highest version as per semantic versioning specification.
     #[inline]
     pub fn highest_version(&self) -> SemverVersion {
         self.versions.iter()
@@ -430,7 +430,7 @@ impl Crate {
             .unwrap()
     }
 
-    /// Returns the highest version as per semantic release specification,
+    /// Returns the highest version as per semantic versioning specification,
     /// filtering out versions with pre-release identifiers.
     #[inline]
     pub fn highest_stable_version(&self) -> Option<SemverVersion> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,16 +417,21 @@ impl Crate {
         &self.versions[self.versions.len() - 1]
     }
 
+    /// Returns the highest version as per semantic release specification.
     #[inline]
     pub fn highest_version(&self) -> SemverVersion {
         self.versions.iter()
             .map(|v| SemverVersion::parse(&v.vers).ok())
             .flatten()
             .max()
-            // Safety: Versions inside the index will always adhere to semantic versioning. If a crate is inside the index, at least one version is inside of it.
+            // Safety: Versions inside the index will always adhere to 
+            // semantic versioning. If a crate is inside the index, at 
+            // least one version is available.
             .unwrap()
     }
 
+    /// Returns the highest version as per semantic release specification,
+    /// filtering out versions with pre-release identifiers.
     pub fn highest_stable_version(&self) -> Option<SemverVersion> {
         self.versions.iter()
             .map(|v| SemverVersion::parse(&v.vers).ok())


### PR DESCRIPTION
This method does return the latest version as specified by the semantic
version specification instead of the "youngest" version of a crate.

Closes #20