### PR TITLE
Add support for bare repos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ edition = "2018"
 [dependencies]
 git2 = "0.13.0"
 glob = "0.3.0"
+hex = { version = "0.4.2", features = ["serde"] }
+home = "0.5.3"
+memchr = "2.3.3"
 semver = "0.10.0"
+serde = "1.0.105"
 serde_derive = "1.0.105"
 serde_json = "1.0.48"
-serde = "1.0.105"
-home = "0.5.3"
 smol_str = { version = "0.1.15", features = ["serde"] }
-hex = { version = "0.4.2", features = ["serde"] }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -7,6 +7,8 @@ pub struct BareIndex {
 }
 
 impl BareIndex {
+    /// Creates a bare index from a provided URL, opening the same location on
+    /// disk that cargo uses for that registry index.
     pub fn from_url(url: &str) -> Result<Self, Error> {
         let (dir_name, canonical_url) = url_to_local_dir(url)?;
         let mut path = home::cargo_home().unwrap_or_default();
@@ -18,6 +20,14 @@ impl BareIndex {
             path,
             url: canonical_url,
         })
+    }
+
+    /// Creates a bare index at the provided path with the specified repository URL.
+    pub fn with_path(path: PathBuf, url: &str) -> Self {
+        Self {
+            path,
+            url: url.to_owned(),
+        }
     }
 
     /// Creates and index for the default crates.io registry
@@ -63,7 +73,7 @@ impl<'a> BareIndexRepo<'a> {
         }
 
         let repo = git2::Repository::open(&index.path)?;
-        let head = repo.refname_to_id("FETCH_HEAD")?;
+        let head = repo.refname_to_id("FETCH_HEAD").or_else(|_| repo.refname_to_id("HEAD"))?;
         let head_str = head.to_string();
 
         let tree = {
@@ -82,6 +92,9 @@ impl<'a> BareIndexRepo<'a> {
         })
     }
 
+    /// Fetches latest from the remote index repository. Note that using this
+    /// method will mean no cache entries will be used, if a new commit is fetched
+    /// from the repository, as their commit version will no longer match.
     pub fn fetch(&mut self) -> Result<(), Error> {
         {
             let mut origin_remote = self.repo
@@ -91,7 +104,7 @@ impl<'a> BareIndexRepo<'a> {
             origin_remote.fetch(&["master"], Some(&mut crate::fetch_opts()), None)?;
         }
 
-        let head = self.repo.refname_to_id("FETCH_HEAD")?;
+        let head = self.repo.refname_to_id("FETCH_HEAD").or_else(|_| self.repo.refname_to_id("HEAD"))?;
         let head_str = head.to_string();
 
         let commit = self.repo.find_commit(head)?;
@@ -106,6 +119,9 @@ impl<'a> BareIndexRepo<'a> {
         Ok(())
     }
 
+    /// Reads a crate from the index, it will attempt to use a cached entry if
+    /// one is available, otherwise it will fallback to reading the crate
+    /// directly from the git blob containing the crate information.
     pub fn krate(&self, name: &str) -> Option<Crate> {
         let rel_path = match crate::crate_name_to_relative_path(name) {
             Some(rp) => rp,
@@ -281,5 +297,93 @@ mod test {
                 crate::INDEX_GIT_URL.to_owned()
             )
         );
+    }
+
+    #[test]
+    fn clones_bare_index() {
+        use super::BareIndex;
+
+        let tmp_dir = tempdir::TempDir::new("clones_bare_index").unwrap();
+
+        let index = BareIndex::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL);
+
+        let mut repo = index.open_or_clone().expect("Failed to clone crates.io index");
+
+        fn test_sval(repo: &super::BareIndexRepo<'_>) {
+            let krate = repo
+                .krate("sval")
+                .expect("Could not find the crate sval in the index");
+
+            let version = krate
+                .versions()
+                .iter()
+                .find(|v| v.version() == "0.0.1")
+                .expect("Version 0.0.1 of sval does not exist?");
+            let dep_with_package_name = version
+                .dependencies()
+                .iter()
+                .find(|d| d.name() == "serde_lib")
+                .expect("sval does not have expected dependency?");
+            assert_ne!(
+                dep_with_package_name.name(),
+                dep_with_package_name.package().unwrap()
+            );
+            assert_eq!(
+                dep_with_package_name.crate_name(),
+                dep_with_package_name.package().unwrap()
+            );
+        }
+
+        test_sval(&repo);
+
+        repo.fetch().expect("Failed to fetch crates.io index");
+
+        test_sval(&repo);
+    }
+
+    #[test]
+    fn opens_bare_index() {
+        use super::BareIndex;
+
+        let tmp_dir = tempdir::TempDir::new("opens_bare_index").unwrap();
+
+        let index = BareIndex::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL);
+
+        {
+            let _ = index.open_or_clone().expect("Failed to clone crates.io index");
+        }
+
+        let mut repo = index.open_or_clone().expect("Failed to open crates.io index");
+
+        fn test_sval(repo: &super::BareIndexRepo<'_>) {
+            let krate = repo
+                .krate("sval")
+                .expect("Could not find the crate sval in the index");
+
+            let version = krate
+                .versions()
+                .iter()
+                .find(|v| v.version() == "0.0.1")
+                .expect("Version 0.0.1 of sval does not exist?");
+            let dep_with_package_name = version
+                .dependencies()
+                .iter()
+                .find(|d| d.name() == "serde_lib")
+                .expect("sval does not have expected dependency?");
+            assert_ne!(
+                dep_with_package_name.name(),
+                dep_with_package_name.package().unwrap()
+            );
+            assert_eq!(
+                dep_with_package_name.crate_name(),
+                dep_with_package_name.package().unwrap()
+            );
+        }
+
+        test_sval(&repo);
+
+        repo.fetch().expect("Failed to fetch crates.io index");
+
+        test_sval(&repo);
     }
 }

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -33,8 +33,9 @@ impl BareIndex {
         }
     }
 
-    /// Creates and index for the default crates.io registry
-    pub fn crates_io() -> Result<Self, Error> {
+    /// Creates an index for the default crates.io registry, using the same
+    /// disk location as cargo itself.
+    pub fn new_cargo_default() -> Result<Self, Error> {
         Self::from_url(crate::INDEX_GIT_URL)
     }
 
@@ -105,7 +106,7 @@ impl<'a> BareIndexRepo<'a> {
     /// Fetches latest from the remote index repository. Note that using this
     /// method will mean no cache entries will be used, if a new commit is fetched
     /// from the repository, as their commit version will no longer match.
-    pub fn fetch(&mut self) -> Result<(), Error> {
+    pub fn retrieve(&mut self) -> Result<(), Error> {
         {
             let mut origin_remote = self
                 .repo
@@ -141,7 +142,7 @@ impl<'a> BareIndexRepo<'a> {
     /// Reads a crate from the index, it will attempt to use a cached entry if
     /// one is available, otherwise it will fallback to reading the crate
     /// directly from the git blob containing the crate information.
-    pub fn krate(&self, name: &str) -> Option<Crate> {
+    pub fn crate_(&self, name: &str) -> Option<Crate> {
         let rel_path = match crate::crate_name_to_relative_path(name) {
             Some(rp) => rp,
             None => return None,
@@ -334,7 +335,7 @@ mod test {
 
         fn test_sval(repo: &super::BareIndexRepo<'_>) {
             let krate = repo
-                .krate("sval")
+                .crate_("sval")
                 .expect("Could not find the crate sval in the index");
 
             let version = krate
@@ -359,7 +360,7 @@ mod test {
 
         test_sval(&repo);
 
-        repo.fetch().expect("Failed to fetch crates.io index");
+        repo.retrieve().expect("Failed to fetch crates.io index");
 
         test_sval(&repo);
     }
@@ -384,7 +385,7 @@ mod test {
 
         fn test_sval(repo: &super::BareIndexRepo<'_>) {
             let krate = repo
-                .krate("sval")
+                .crate_("sval")
                 .expect("Could not find the crate sval in the index");
 
             let version = krate
@@ -409,7 +410,7 @@ mod test {
 
         test_sval(&repo);
 
-        repo.fetch().expect("Failed to fetch crates.io index");
+        repo.retrieve().expect("Failed to fetch crates.io index");
 
         test_sval(&repo);
     }

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -1,0 +1,234 @@
+use crate::{Crate, Error};
+use std::path::PathBuf;
+
+pub struct BareIndex {
+    path: PathBuf,
+    url: String,
+}
+
+impl BareIndex {
+    pub fn from_url(url: &str) -> Result<Self, Error> {
+        let (dir_name, canonical_url) = url_to_local_dir(url)?;
+        let mut path = home::cargo_home().unwrap_or_default();
+
+        path.push("registry/index");
+        path.push(dir_name);
+
+        Ok(Self {
+            path,
+            url: canonical_url,
+        })
+    }
+
+    /// Creates and index for the default crates.io registry
+    pub fn crates_io() -> Result<Self, Error> {
+        Self::from_url(crate::INDEX_GIT_URL)
+    }
+
+    /// Opens the local index, which acts as a kind of lock for source control
+    /// operations
+    pub fn open(&'a self) -> BareIndexRepo<'a> {
+        BareIndexRepo::new(self)
+    }
+
+    pub fn krate(&self, name: &str) -> Option<Crate> {
+        let rel_path = match crate::crate_name_to_relative_path(name) {
+            Some(rp) => rp,
+            None => return None,
+        };
+
+        // Attempt to load the .cache/ entry first, this is purely an acceleration
+        // mechanism and can fail for a few reasons that are non-fatal
+        {
+            let mut cache_path = self.path.join(".cache");
+            cache_path.push(rel_path);
+            if let Ok(cache_bytes) = std::fs::read(&cache_path) {
+                if let Some(krate) = Crate::from_cache_slice(&cache_bytes) {
+                    return Some(krate);
+                }
+            }
+        }
+
+        // // Fallback to reading the blob directly if we don't have a valid cache entry
+        // let repo = self.repo()?;
+        // let tree = self.tree()?;
+        // let entry = tree.get_path(path)?;
+        // let object = entry.to_object(repo)?;
+        // let blob = match object.as_blob() {
+        //     Some(blob) => blob,
+        //     None => anyhow::bail!("path `{}` is not a blob in the git repo", path.display()),
+        // };
+
+        unimplemented!()
+    }
+}
+
+pub struct BareIndexRepo<'a> {
+    inner: &'a BareIndex,
+    head: Option<git2::Oid>,
+    repo: Option<git2::Repository>,
+}
+
+impl<'a> BareIndexRepo<'a> {
+    fn new(index: &'a BareIndex) -> Self {
+        Self {
+            inner: index,
+            head: None,
+            repo: None,
+        }
+    }
+
+    pub fn exists(&self) -> bool {
+        git2::Repository::discover(&self.inner.path)
+            .map(|repository| {
+                repository
+                    .find_remote("origin")
+                    .ok()
+                    // Cargo creates a checkout without an origin set,
+                    // so default to true in case of missing origin
+                    .map_or(true, |remote| {
+                        remote.url().map_or(true, |url| url == self.inner.url)
+                    })
+            })
+            .unwrap_or(false)
+    }
+
+/// Converts a full url, eg, into the root directory name where cargo itself
+/// will fetch it on disk
+fn url_to_local_dir(url: &str) -> Result<(String, String), Error> {
+    fn to_hex(num: u64) -> String {
+        const CHARS: &[u8] = b"0123456789abcdef";
+
+        let bytes = &[
+            num as u8,
+            (num >> 8) as u8,
+            (num >> 16) as u8,
+            (num >> 24) as u8,
+            (num >> 32) as u8,
+            (num >> 40) as u8,
+            (num >> 48) as u8,
+            (num >> 56) as u8,
+        ];
+
+        let mut output = vec![0u8; 16];
+
+        let mut ind = 0;
+
+        for &byte in bytes {
+            output[ind] = CHARS[(byte >> 4) as usize];
+            output[ind + 1] = CHARS[(byte & 0xf) as usize];
+
+            ind += 2;
+        }
+
+        String::from_utf8(output).expect("valid utf-8 hex string")
+    }
+
+    #[allow(deprecated)]
+    fn hash_u64(url: &str) -> u64 {
+        use std::hash::{Hash, Hasher, SipHasher};
+
+        let mut hasher = SipHasher::new_with_keys(0, 0);
+        // Registry
+        2usize.hash(&mut hasher);
+        // Url
+        url.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    // Ensure we have a registry or bare url
+    let (url, scheme_ind) = {
+        let scheme_ind = url
+            .find("://")
+            .ok_or_else(|| Error::Url(format!("'{}' is not a valid url", url)))?;
+
+        let scheme_str = &url[..scheme_ind];
+        if let Some(ind) = scheme_str.find('+') {
+            if &scheme_str[..ind] != "registry" {
+                return Err(Error::Url(format!("'{}' is not a valid registry url", url)));
+            }
+
+            (&url[ind + 1..], scheme_ind - ind - 1)
+        } else {
+            (url, scheme_ind)
+        }
+    };
+
+    // Could use the Url crate for this, but it's simple enough and we don't
+    // need to deal with every possible url (I hope...)
+    let host = match url[scheme_ind + 3..].find('/') {
+        Some(end) => &url[scheme_ind + 3..scheme_ind + 3 + end],
+        None => &url[scheme_ind + 3..],
+    };
+
+    // cargo special cases github.com for reasons, so do the same
+    let mut canonical = if host == "github.com" {
+        url.to_lowercase()
+    } else {
+        url.to_owned()
+    };
+
+    // Chop off any query params/fragments
+    if let Some(hash) = canonical.rfind('#') {
+        canonical.truncate(hash);
+    }
+
+    if let Some(query) = canonical.rfind('?') {
+        canonical.truncate(query);
+    }
+
+    println!("hashing {}", canonical);
+    let ident = to_hex(hash_u64(&canonical));
+
+    if canonical.ends_with('/') {
+        canonical.pop();
+    }
+
+    if canonical.ends_with(".git") {
+        canonical.truncate(canonical.len() - 4);
+    }
+
+    Ok((format!("{}-{}", host, ident), canonical))
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn matches_cargo() {
+        assert_eq!(
+            super::url_to_local_dir(crate::INDEX_GIT_URL).unwrap(),
+            (
+                "github.com-1ecc6299db9ec823".to_owned(),
+                crate::INDEX_GIT_URL.to_owned()
+            )
+        );
+
+        // I've confirmed this also works with a custom registry, unfortunately
+        // that one includes a secret key as part of the url which would allow
+        // anyone to publish to the registry, so uhh...here's a fake one instead
+        assert_eq!(
+            super::url_to_local_dir(
+                "https://dl.cloudsmith.io/aBcW1234aBcW1234/embark/rust/cargo/index.git"
+            )
+            .unwrap(),
+            (
+                "dl.cloudsmith.io-ff79e51ddd2b38fd".to_owned(),
+                "https://dl.cloudsmith.io/aBcW1234aBcW1234/embark/rust/cargo/index".to_owned()
+            )
+        );
+
+        // Ensure we actually strip off the irrelevant parts of a url, note that
+        // the .git suffix is not part of the canonical url, but it used when hashing
+        assert_eq!(
+            super::url_to_local_dir(&format!(
+                "registry+{}.git?one=1&two=2#fragment",
+                crate::INDEX_GIT_URL
+            ))
+            .unwrap(),
+            (
+                "github.com-c786010fb7ef2e6e".to_owned(),
+                crate::INDEX_GIT_URL.to_owned()
+            )
+        );
+    }
+}

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -3,7 +3,7 @@ use std::{io, path::{Path, PathBuf}};
 
 pub struct BareIndex {
     path: PathBuf,
-    url: String,
+    pub url: String,
 }
 
 impl BareIndex {

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -1,5 +1,8 @@
 use crate::{Crate, Error};
-use std::{io, path::{Path, PathBuf}};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 pub struct BareIndex {
     path: PathBuf,
@@ -73,7 +76,9 @@ impl<'a> BareIndexRepo<'a> {
         }
 
         let repo = git2::Repository::open(&index.path)?;
-        let head = repo.refname_to_id("FETCH_HEAD").or_else(|_| repo.refname_to_id("HEAD"))?;
+        let head = repo
+            .refname_to_id("FETCH_HEAD")
+            .or_else(|_| repo.refname_to_id("HEAD"))?;
         let head_str = head.to_string();
 
         let tree = {
@@ -97,14 +102,18 @@ impl<'a> BareIndexRepo<'a> {
     /// from the repository, as their commit version will no longer match.
     pub fn fetch(&mut self) -> Result<(), Error> {
         {
-            let mut origin_remote = self.repo
-            .find_remote("origin")
-            .or_else(|_| self.repo.remote_anonymous(&self.inner.url))?;
+            let mut origin_remote = self
+                .repo
+                .find_remote("origin")
+                .or_else(|_| self.repo.remote_anonymous(&self.inner.url))?;
 
             origin_remote.fetch(&["master"], Some(&mut crate::fetch_opts()), None)?;
         }
 
-        let head = self.repo.refname_to_id("FETCH_HEAD").or_else(|_| self.repo.refname_to_id("HEAD"))?;
+        let head = self
+            .repo
+            .refname_to_id("FETCH_HEAD")
+            .or_else(|_| self.repo.refname_to_id("HEAD"))?;
         let head_str = head.to_string();
 
         let commit = self.repo.find_commit(head)?;
@@ -148,7 +157,9 @@ impl<'a> BareIndexRepo<'a> {
     fn krate_from_blob(&self, path: &str) -> Result<Crate, Error> {
         let entry = self.tree.as_ref().unwrap().get_path(&Path::new(path))?;
         let object = entry.to_object(&self.repo)?;
-        let blob = object.as_blob().ok_or_else(|| Error::Io(io::Error::new(io::ErrorKind::NotFound, path.to_owned())))?;
+        let blob = object
+            .as_blob()
+            .ok_or_else(|| Error::Io(io::Error::new(io::ErrorKind::NotFound, path.to_owned())))?;
 
         Crate::from_slice(blob.content()).map_err(Error::Io)
     }
@@ -307,7 +318,9 @@ mod test {
 
         let index = BareIndex::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL);
 
-        let mut repo = index.open_or_clone().expect("Failed to clone crates.io index");
+        let mut repo = index
+            .open_or_clone()
+            .expect("Failed to clone crates.io index");
 
         fn test_sval(repo: &super::BareIndexRepo<'_>) {
             let krate = repo
@@ -350,10 +363,14 @@ mod test {
         let index = BareIndex::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL);
 
         {
-            let _ = index.open_or_clone().expect("Failed to clone crates.io index");
+            let _ = index
+                .open_or_clone()
+                .expect("Failed to clone crates.io index");
         }
 
-        let mut repo = index.open_or_clone().expect("Failed to open crates.io index");
+        let mut repo = index
+            .open_or_clone()
+            .expect("Failed to open crates.io index");
 
         fn test_sval(repo: &super::BareIndexRepo<'_>) {
             let krate = repo

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,35 @@
+use std::{fmt, io::Error as IoErr};
+use git2::Error as GitErr;
+
+#[derive(Debug)]
+pub enum Error {
+    Git(GitErr),
+    Url(String),
+    Io(IoErr),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Git(e) => fmt::Display::fmt(&e, f),
+            Self::Url(u) => f.write_str(&u),
+            Self::Io(e) => fmt::Display::fmt(&e, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Git(e) => Some(e),
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<GitErr> for Error {
+    fn from(e: GitErr) -> Self {
+        Self::Git(e)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::{fmt, io::Error as IoErr};
 use git2::Error as GitErr;
+use std::{fmt, io::Error as IoErr};
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,11 @@
 use semver::Version as SemverVersion;
 use serde_derive::{Deserialize, Serialize};
 use smol_str::SmolStr;
-use std::collections::HashMap;
-use std::fmt;
-use std::io;
-use std::iter;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fmt, io, iter,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug)]
 pub enum Error {
@@ -494,8 +494,7 @@ impl From<git2::Error> for Error {
 
 #[cfg(test)]
 mod test {
-    use super::Crate;
-    use super::Index;
+    use super::{Crate, Index};
     use tempdir::TempDir;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod bare_index;
+
+pub use bare_index::BareIndex;
+
 #[derive(Debug)]
 pub enum Error {
     Git(git2::Error),
+    Url(String),
 }
 
 static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
@@ -320,33 +325,16 @@ impl Index {
 
     /// Retrieve a single crate by name (case insensitive) from the index
     pub fn crate_(&self, crate_name: &str) -> Option<Crate> {
-        if !crate_name.is_ascii() {
-            return None;
-        }
-        let name_lower = crate_name.to_ascii_lowercase();
-        let mut rel_path = String::with_capacity(crate_name.len() + 6);
-        match name_lower.len() {
-            0 => return None,
-            1 => rel_path.push('1'),
-            2 => rel_path.push('2'),
-            3 => {
-                rel_path.push('3');
-                rel_path.push(std::path::MAIN_SEPARATOR);
-                rel_path.push_str(&name_lower[0..1]);
+        match crate_name_to_relative_path(crate_name) {
+            Some(rel_path) => {
+                let path = self.path.join(rel_path);
+                if path.exists() {
+                    Crate::new(path.as_path()).ok()
+                } else {
+                    None
+                }
             }
-            _ => {
-                rel_path.push_str(&name_lower[0..2]);
-                rel_path.push(std::path::MAIN_SEPARATOR);
-                rel_path.push_str(&name_lower[2..4]);
-            }
-        };
-        rel_path.push(std::path::MAIN_SEPARATOR);
-        rel_path.push_str(&name_lower);
-        let path = self.path.join(rel_path);
-        if path.exists() {
-            Crate::new(path.as_path()).ok()
-        } else {
-            None
+            None => None,
         }
     }
 
@@ -365,6 +353,34 @@ impl Index {
     pub fn path(&self) -> &Path {
         &self.path
     }
+}
+
+fn crate_name_to_relative_path(crate_name: &str) -> Option<String> {
+    if !crate_name.is_ascii() {
+        return None;
+    }
+
+    let name_lower = crate_name.to_ascii_lowercase();
+    let mut rel_path = String::with_capacity(crate_name.len() + 6);
+    match name_lower.len() {
+        0 => return None,
+        1 => rel_path.push('1'),
+        2 => rel_path.push('2'),
+        3 => {
+            rel_path.push('3');
+            rel_path.push(std::path::MAIN_SEPARATOR);
+            rel_path.push_str(&name_lower[0..1]);
+        }
+        _ => {
+            rel_path.push_str(&name_lower[0..2]);
+            rel_path.push(std::path::MAIN_SEPARATOR);
+            rel_path.push_str(&name_lower[2..4]);
+        }
+    };
+    rel_path.push(std::path::MAIN_SEPARATOR);
+    rel_path.push_str(&name_lower);
+
+    Some(rel_path)
 }
 
 /// A single crate that contains many published versions
@@ -414,6 +430,86 @@ impl Crate {
         }
         debug_assert_eq!(versions.len(), versions.capacity());
         Ok(Crate {
+            versions: versions.into_boxed_slice(),
+        })
+    }
+
+    /// Parse crate index entry from a .cache file, this can fail for a number of reasons
+    ///
+    /// 1. There is no entry for this crate
+    /// 2. The entry was created with an older commit and might be outdated
+    /// 3. The entry is a newer version than what can be read, would only
+    /// happen if a future version of cargo changed the format of the cache entries
+    /// 4. The cache entry is malformed somehow
+    pub fn from_cache_slice(mut bytes: &[u8], index_version: &str) -> io::Result<Crate> {
+        const CURRENT_CACHE_VERSION: u8 = 1;
+
+        // See src/cargo/sources/registry/index.rs
+        let (first_byte, rest) = bytes
+            .split_first()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "malformed cache"))?;
+
+        if *first_byte != CURRENT_CACHE_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "looks like a different Cargo's cache, bailing out",
+            ));
+        }
+
+        fn split<'a>(haystack: &'a [u8], needle: u8) -> impl Iterator<Item = &'a [u8]> + 'a {
+            struct Split<'a> {
+                haystack: &'a [u8],
+                needle: u8,
+            }
+
+            impl<'a> Iterator for Split<'a> {
+                type Item = &'a [u8];
+
+                fn next(&mut self) -> Option<&'a [u8]> {
+                    if self.haystack.is_empty() {
+                        return None;
+                    }
+                    let (ret, remaining) = match memchr::memchr(self.needle, self.haystack) {
+                        Some(pos) => (&self.haystack[..pos], &self.haystack[pos + 1..]),
+                        None => (self.haystack, &[][..]),
+                    };
+                    self.haystack = remaining;
+                    Some(ret)
+                }
+            }
+
+            Split { haystack, needle }
+        }
+
+        let mut iter = split(rest, 0);
+        if let Some(update) = iter.next() {
+            if update != index_version.as_bytes() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "cache out of date: current index ({}) != cache ({})",
+                        index_version,
+                        std::str::from_utf8(update)
+                            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?,
+                    ),
+                ))?;
+            }
+        } else {
+            return Err(io::Error::new(io::ErrorKind::Other, "malformed file"));
+        }
+
+        let mut versions = Vec::new();
+
+        // Each entry is a tuple of (semver, version_json)
+        while let Some(version) = iter.next() {
+            iter.next()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "malformed file"))?;
+            let version: Version = serde_json::from_slice(version)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            versions.push(version);
+        }
+
+        Ok(Self {
             versions: versions.into_boxed_slice(),
         })
     }
@@ -474,6 +570,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Git(e) => fmt::Display::fmt(&e, f),
+            Self::Url(u) => f.write_str(&u),
         }
     }
 }
@@ -482,6 +579,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Git(e) => Some(e),
+            Self::Url(_) => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,7 @@ impl Crate {
         let mut versions = Vec::new();
 
         // Each entry is a tuple of (semver, version_json)
-        while let Some(version) = iter.next() {
+        while let Some(_version) = iter.next() {
             let version_slice = iter
                 .next()
                 .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "malformed file"))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,8 @@ impl Crate {
 
         // Each entry is a tuple of (semver, version_json)
         while let Some(version) = iter.next() {
-            let version_slice = iter.next()
+            let version_slice = iter
+                .next()
                 .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "malformed file"))?;
             let version: Version = serde_json::from_slice(version_slice)
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,9 +498,9 @@ impl Crate {
 
         // Each entry is a tuple of (semver, version_json)
         while let Some(version) = iter.next() {
-            iter.next()
+            let version_slice = iter.next()
                 .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "malformed file"))?;
-            let version: Version = serde_json::from_slice(version)
+            let version: Version = serde_json::from_slice(version_slice)
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
             versions.push(version);
         }


### PR DESCRIPTION
This mostly resolves #17, though it just supports reading specific crates, not iteration, though that could be added if desirable.

* Adds `BareIndex` which is just a wrapper around a repository url and a local path
* Adds `BareIndexRepo` which is created via `BareIndex::open_or_clone()` and keeps a the git repository details needed for reading crate contents on demand, and allows fetching updates
* Adds support for reading cargo's `.cache` entries, which are created by cargo whenever it reads a crate from the index so that it doesn't have to fetch the git blob, but falls back to reading the entry from the git blob if the cache entry doesn't exist.

Additional:
* Fixed a bug where 3 letter long crate names were skipped when iterating