### PR TITLE
Reduce the size of checkouts

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -80,14 +80,26 @@ impl<'a> BareIndexRepo<'a> {
             })
             .unwrap_or(false);
 
-        if !exists {
-            git2::build::RepoBuilder::new()
-                .fetch_options(crate::fetch_opts())
-                .bare(true)
-                .clone(&index.url, &index.path)?;
-        }
+        let repo = if !exists {
+            let mut opts = git2::RepositoryInitOptions::new();
+            opts.external_template(false);
+            let repo = git2::Repository::init_opts(&index.path, &opts)?;
+            {
+                let mut origin_remote = repo
+                    .find_remote("origin")
+                    .or_else(|_| repo.remote_anonymous(&index.url))?;
 
-        let repo = git2::Repository::open(&index.path)?;
+                origin_remote.fetch(
+                    &["HEAD:refs/remotes/origin/HEAD"],
+                    Some(&mut crate::fetch_opts()),
+                    None,
+                )?;
+            }
+            repo
+        } else {
+            git2::Repository::open(&index.path)?
+        };
+
         let head = repo
             // Fallback to HEAD, as a fresh clone won't have a FETCH_HEAD
             .refname_to_id("FETCH_HEAD")
@@ -106,10 +118,7 @@ impl<'a> BareIndexRepo<'a> {
             inner: index,
             head,
             head_str,
-            rt: UnsafeRepoTree {
-                repo,
-                tree,
-            },
+            rt: UnsafeRepoTree { repo, tree },
         })
     }
 
@@ -119,7 +128,8 @@ impl<'a> BareIndexRepo<'a> {
     pub fn retrieve(&mut self) -> Result<(), Error> {
         {
             let mut origin_remote = self
-                .rt.repo
+                .rt
+                .repo
                 .find_remote("origin")
                 .or_else(|_| self.rt.repo.remote_anonymous(&self.inner.url))?;
 
@@ -131,7 +141,8 @@ impl<'a> BareIndexRepo<'a> {
         }
 
         let head = self
-            .rt.repo
+            .rt
+            .repo
             .refname_to_id("FETCH_HEAD")
             .or_else(|_| self.rt.repo.refname_to_id("HEAD"))?;
         let head_str = head.to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,9 +290,10 @@ impl Index {
 
     /// Downloads the index to the path specified from the constructor
     pub fn retrieve(&self) -> Result<(), Error> {
-        git2::build::RepoBuilder::new()
-            .fetch_options(fetch_opts())
-            .clone(INDEX_GIT_URL, &self.path)?;
+        let mut opts = git2::RepositoryInitOptions::new();
+        opts.external_template(false);
+        git2::Repository::init_opts(&self.path, &opts)?;
+        self.update()?;
         Ok(())
     }
 


### PR DESCRIPTION
https://stackoverflow.com/a/27320456/831850 claims "Actually, by default, Clone() takes care of locally retrieving all commits of all branches. By default, only the remote HEAD branch (generally origin/master), gets an automatically created local branch counterpart, which is then checked out."

Copying some code from https://github.com/rust-lang/cargo/blob/963bfe4dd9e3b35738182f4e1667c0197d2ab60c/src/cargo/sources/registry/remote.rs#L95

I was able to get the same size checkouts as cargo for bareindex and double cargos size for normal indexes.
I don't know much about this, so fixes are welcome, but this seemed like a good POC.

Fix #47