### PR TITLE
Checkout `HEAD` instead of `master`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,7 +312,7 @@ impl Index {
         let mut origin_remote = repo
             .find_remote("origin")
             .or_else(|_| repo.remote_anonymous(INDEX_GIT_URL))?;
-        origin_remote.fetch(&["master"], Some(&mut fetch_opts()), None)?;
+        origin_remote.fetch(&["HEAD"], Some(&mut fetch_opts()), None)?;
         let oid = repo.refname_to_id("FETCH_HEAD")?;
         let object = repo.find_object(oid, None).unwrap();
         repo.reset(&object, git2::ResetType::Hard, None)?;


### PR DESCRIPTION
In cargo, [`HEAD`] is updated instead of `master`. This mismatch means that the two refs can drift, depending on when cargo and this library last fetched changes.

I believe this change will fix sunng87/cargo-release#224. In that bug, it is first confirmed (by fetching `master`) that a recently published crate is now available in the public index. Once the dependency is published, it should be safe to publish new crates which depend on it. However, when the next crate is published the local build fails because `cargo` is using a less recent `HEAD`, which was not updated by `crates-index`.

The change brings this implementation into alignment with [`src/bare_index.rs`].

[`HEAD`]: https://github.com/rust-lang/cargo/blob/0b2059e9811caa238a603f0300d9c5fb485000a6/src/cargo/sources/registry/remote.rs#L56
[`src/bare_index.rs`]: https://github.com/frewsxcv/rust-crates-index/blob/master/src/bare_index.rs#L140