### PR TITLE
Allow parsing config.json data from an index

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -1,4 +1,4 @@
-use crate::{Crate, Error};
+use crate::{Crate, Error, IndexConfig};
 use std::marker::PhantomPinned;
 use std::{
     io,
@@ -231,6 +231,16 @@ impl<'a> BareIndexRepo<'a> {
             stack,
             rt: &self.rt,
         }
+    }
+
+    /// Get the global configuration of the index.
+    pub fn index_config(&self) -> Result<IndexConfig, Error> {
+        let entry = self.rt.tree.get_path(&Path::new("config.json"))?;
+        let object = entry.to_object(&self.rt.repo)?;
+        let blob = object
+            .as_blob()
+            .ok_or_else(|| Error::Io(io::Error::new(io::ErrorKind::NotFound, "config.json")))?;
+        serde_json::from_slice(blob.content()).map_err(Error::Json)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use git2::Error as GitErr;
+use serde_json::Error as SerdeJsonError;
 use std::{fmt, io::Error as IoErr};
 
 #[derive(Debug)]
@@ -6,6 +7,7 @@ pub enum Error {
     Git(GitErr),
     Url(String),
     Io(IoErr),
+    Json(SerdeJsonError),
 }
 
 impl fmt::Display for Error {
@@ -14,6 +16,7 @@ impl fmt::Display for Error {
             Self::Git(e) => fmt::Display::fmt(&e, f),
             Self::Url(u) => f.write_str(&u),
             Self::Io(e) => fmt::Display::fmt(&e, f),
+            Self::Json(e) => fmt::Display::fmt(&e, f),
         }
     }
 }


### PR DESCRIPTION
This is described in https://doc.rust-lang.org/cargo/reference/registries.html#index-format
and allows parsing out download URLs for crates in the index.