### PR TITLE
Allow building without an openssl dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/crates-index/"
 edition = "2018"
 
 [dependencies]
-git2 = "0.13.20"
+git2 = { version = "0.13.20", default-features = false }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.3"
 memchr = "2.4.0"
@@ -30,4 +30,5 @@ cap = "0.1.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+default = ["git2/default"]
 vendored-openssl = ["git2/vendored-openssl"]


### PR DESCRIPTION
With this change, users can depend on this crate and disable default features to avoid a dependency on OpenSSL
```toml
[dependencies]
crates-index = { version = "0.18.0", default-features = false }
```
```
rust-crates-index % cargo tree --no-default-features | grep openssl

```

vs with default features enabled
```
rust-crates-index % cargo tree | grep openssl
│   │   │   └── openssl-sys v0.9.67
│   │   └── openssl-sys v0.9.67 (*)
```

closes https://github.com/frewsxcv/rust-crates-index/issues/64