### PR TITLE
feat: Support non-crates.io registries

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -445,7 +445,8 @@ fn url_to_local_dir(url: &str) -> Result<(String, String), Error> {
         canonical.pop();
     }
 
-    if canonical.ends_with(".git") {
+    if canonical.contains("github.com/") && canonical.ends_with(".git") {
+        // Only GitHub (crates.io) repositories have their .git suffix truncated
         canonical.truncate(canonical.len() - 4);
     }
 


### PR DESCRIPTION
This matches cargo's behavior for registries that are not hosted on
GitHub (like Cloudsmith), and uses the configured git credential helper
to allow cloning private registries.

Needed for https://github.com/pksunkara/cargo-workspaces/pull/53

---

I'm as surprised as you probably are that cargo normalizes:

```
this:
https://github.com/rust-lang/crates.io-index.git
to this:
https://github.com/rust-lang/crates.io-index
```

But keeps something like `https://dl.cloudsmith.io/basic/myorg/myrepo/cargo/index.git` as-is. But if we don't reproduce cargo's behavior there, we won't use the same checkout directories, using up more disk space and being generally out-of-sync with cargo.

The other change is rather straightforward, I'm not sure why it's not libgit2's default, but apparently you need to spell out "please use the configured git credential helper to clone stuff". At least for Cloudsmith crate registries, that's a prerequisite - every user gets their own API token that's configured in something like `~/.git-credentials`:

```
https://fasterthanlime:my_github_token@github.com
https://fasterthanlime:my_cloudsmith_token@dl.cloudsmith.io
```

...or really any of the Git credential helpers that exist. The bit of config in that PR should work no matter the credential helper, whether it's "store", some GUI thing on Windows, VSCode's odd "git credential forwarding helper" for dev containers, etc.