### PR TITLE
chore: Switch to shields.io for badge, closes #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-crates-index
 
-[![crates-index on Crates.io](https://meritbadge.herokuapp.com/crates-index)](https://crates.rs/crates/crates-index)
+[![crates-index on Crates.io](https://img.shields.io/crates/v/crates-index.svg)](https://lib.rs/crates/crates-index)
 
 Library for retrieving and interacting with the [crates.io registry git-based index](https://github.com/rust-lang/crates.io-index).
 


### PR DESCRIPTION
`crates.rs` appears to be the previous name for `lib.rs`, so I also changed that to point to `lib.rs` directly (which is a much nicer landing page than crates.io)