### PR TITLE
docs + fmt: Unconstrained expectations

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -156,7 +156,8 @@ impl Index {
             )?;
         }
 
-        let head = self.repo
+        let head = self
+            .repo
             .refname_to_id("FETCH_HEAD")
             .or_else(|_| self.repo.refname_to_id("HEAD"))?;
 
@@ -182,7 +183,8 @@ impl Index {
         // mechanism and can fail for a few reasons that are non-fatal
         {
             // avoid realloc on each push
-            let mut cache_path = PathBuf::with_capacity(path_min_byte_len(&self.path) + 8 + rel_path.len());
+            let mut cache_path =
+                PathBuf::with_capacity(path_min_byte_len(&self.path) + 8 + rel_path.len());
             cache_path.push(&self.path);
             cache_path.push(".cache");
             cache_path.push(&rel_path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ fn crate_name_to_relative_path(crate_name: &str) -> Option<String> {
     Some(rel_path)
 }
 
-/// A single crate that contains many published versions
+/// A single crate
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Crate {
     versions: Box<[Version]>,
@@ -453,27 +453,33 @@ impl Crate {
         })
     }
 
-    /// Published versions of this crate sorted chronologically by date published
+    /// Unconstrained All versions of this crate sorted chronologically by date originally published
+    ///
+    /// Warning: may be yanked or duplicate
     #[inline]
     pub fn versions(&self) -> &[Version] {
         &self.versions
     }
 
-    /// Oldest version.
+    /// Unconstrained Earliest version
     ///
-    /// Warning: may not be the lowest version number.
+    /// Warning: may not be the lowest version number and may be yanked or duplicate
     #[inline]
     pub fn earliest_version(&self) -> &Version {
         &self.versions[0]
     }
 
-    /// Most recently published version. Warning: may not be the highest version.
+    /// Unconstrained Latest version
+    ///
+    /// Warning: may not be the highest version and may be yanked or duplicate
     #[inline]
     pub fn latest_version(&self) -> &Version {
         &self.versions[self.versions.len() - 1]
     }
 
-    /// Returns the highest version as per semantic versioning specification, including unstable versions.
+    /// Returns the highest version as per semantic versioning specification
+    ///
+    /// Warning: may be unstable or yanked or duplicate
     pub fn highest_version(&self) -> &Version {
         self.versions
             .iter()
@@ -486,6 +492,8 @@ impl Crate {
 
     /// Returns the highest version as per semantic versioning specification,
     /// filtering out versions with pre-release identifiers.
+    ///
+    /// Warning: may be yanked or duplicate
     pub fn highest_stable_version(&self) -> Option<&Version> {
         self.versions
             .iter()

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -13,6 +13,11 @@ fn mem_usage() {
     let all_crates: Vec<_> = index.crates().collect();
     let after = ALLOCATOR.allocated();
     let used = after - before;
-    eprintln!("used mem: {}B for {} crates, {}B per crate", used, all_crates.len(), used / all_crates.len());
+    eprintln!(
+        "used mem: {}B for {} crates, {}B per crate",
+        used,
+        all_crates.len(),
+        used / all_crates.len()
+    );
     assert!(used / all_crates.len() < 4900);
 }


### PR DESCRIPTION
Fixes #73 

I added the constraints as Warnings and listed Unconstrained to signal this.

I realised that CI doesn't enforce rustfmt so there is some minor rustfmt in addition (sowwy!)