### PR TITLE
upgrade `git2` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/crates-index/"
 edition = "2018"
 
 [dependencies]
-git2 = { version = "0.13.25", default-features = false }
+git2 = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.3"
 memchr = "2.4.1"


### PR DESCRIPTION
I was upgrading dependencies for in docs.rs, and stumbled onto this issue. 

Problem is that `git2` upgraded `libgit2-sys` to `1.4.0`, which then leads to a conflict (_failed to select a version for `libgit2-sys`_) when an application has the `git2==0.14.0` in its dependencies. 