### PR TITLE
replace tempdir crate with tempfile, as tempfile have superseded tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.79"
 smartstring = { version = "1.0.0", features = ["serde"] }
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 cap = "0.1.0"
 
 [package.metadata.docs.rs]

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -531,7 +531,7 @@ mod test {
     fn bare_iterator() {
         use super::Index;
 
-        let tmp_dir = tempdir::TempDir::new("bare_iterator").unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
             .expect("Failed to clone crates.io index");
@@ -557,7 +557,7 @@ mod test {
     fn clones_bare_index() {
         use super::Index;
 
-        let tmp_dir = tempdir::TempDir::new("clones_bare_index").unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let mut repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
             .expect("Failed to clone crates.io index");
@@ -598,7 +598,7 @@ mod test {
     fn opens_bare_index() {
         use super::Index;
 
-        let tmp_dir = tempdir::TempDir::new("opens_bare_index").unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let mut repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
             .expect("Failed to open crates.io index");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,7 +545,7 @@ impl IndexConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[test]
     fn sizes() {
@@ -616,7 +616,7 @@ mod test {
 
     #[test]
     fn test_can_parse_all() {
-        let tmp_dir = TempDir::new("test3").unwrap();
+        let tmp_dir = TempDir::new().unwrap();
         let mut found_gcc_crate = false;
 
         let index = Index::with_path(tmp_dir.path(), crate::INDEX_GIT_URL).unwrap();


### PR DESCRIPTION
Deprecation note here: https://crates.io/crates/tempdir