### PR TITLE
expose index url

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -62,6 +62,13 @@ impl Index {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Get the index url.
+    #[inline]
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
 }
 
 impl Index {


### PR DESCRIPTION
I am writing code to publish to different indexes.
For debugging, it would be nice to be able to distinguish between the various indexes.