### PR TITLE
Start using `smol_str` again to avoid MPL 2.0 license of `smartstring`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ semver = "1.0.14"
 serde = { version = "1.0.147", features = ["rc"] }
 serde_derive = "1.0.147"
 serde_json = "1.0.87"
-smartstring = { version = "1.0.1", features = ["serde"] }
+smol_str = { version = "0.1.23", features = ["serde"] }
 toml = "0.5.9"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ use dedupe::DedupeContext;
 use git2::{Config, Cred, CredentialHelper, RemoteCallbacks};
 use semver::Version as SemverVersion;
 use serde_derive::{Deserialize, Serialize};
-use smartstring::alias::String as SmolStr;
+use smol_str::SmolStr as SmolStr;
 use std::collections::HashMap;
 use std::io;
 use std::path::Path;


### PR DESCRIPTION
Hi and thank you for this very useful project :pray: 

I noticed that in https://github.com/frewsxcv/rust-crates-index/commit/7e945b37dc94a442438bd1d8c2da9ee81ac3f0ad, `smol_str` was replaced by `smartstring` for MSRV reasons.

What is the MSRV for this project? Is it higher than 1.45? If so, we should be able to go back to `smol_str`. I can run `cargo test` on `smol_str` with 1.46, but not 1.45. So I think the effective MSRV of `smol_str` `0.1.23` is 1.46.

The downside of `smartstring` is that it is licensed under MPL 2.0, which has a copyleft flavor to it, which some can find concerning. `smol_str` is `MIT OR APACHE-2.0`.

Inte: The officiell MSRV policy of `smol_str` is "latest stable". Maybe that is a problem. Another option to this PR could be to add a feature where `smol_str` OR `smartstring` can be chosen.

Thank you in advance for any guidance or pointers.