### PR TITLE
Allow enabling the https feature by itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ cap = "0.1.1"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["git2/https", "parallel"]
+default = ["https", "parallel"]
+https = ["git2/https"]
 parallel = ["dep:rayon"]
 vendored-openssl = ["git2/vendored-openssl"]
 ssh = ["git2/ssh"]


### PR DESCRIPTION
Currently, it is not possible to enable `https` without also enabling `parallel`.