### PR TITLE
Add umbrella `Index` type to handle multiple index types

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -78,7 +78,7 @@ impl Index {
     ///
     /// It can be used to access custom registries.
     pub fn from_url(url: &str) -> Result<Self, Error> {
-        let (dir_name, canonical_url) = url_to_local_dir(url)?;
+        let (dir_name, canonical_url, _kind) = url_to_local_dir(url)?;
         let mut path = home::cargo_home()?;
 
         path.push("registry");
@@ -110,7 +110,7 @@ impl Index {
 }
 
 impl Index {
-    fn from_path_and_url(path: PathBuf, url: String) -> Result<Self, Error> {
+    pub(crate) fn from_path_and_url(path: PathBuf, url: String) -> Result<Self, Error> {
         let exists = git2::Repository::discover(&path)
             .map(|repository| {
                 repository

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,49 @@
+use crate::{Crate, Error};
+use crate::dirs::{url_to_local_dir, RegistryKind};
+use crate::{sparse_index, bare_index};
+
+/// A crates index (either a bare git checkout or a sparse HTTP cache)
+pub enum Index {
+    /// A sparse HTTP index
+    Sparse(sparse_index::Index),
+    /// A bare Git index
+    Bare(bare_index::Index),
+}
+
+impl Index {
+    /// Creates a view of the provided index URL, auto-detecting the underlying type of the
+    /// registry.
+    pub fn from_url(url: &str) -> Result<Self, Error> {
+        let (dir, url, kind) = url_to_local_dir(url)?;
+        let mut path = home::cargo_home()?;
+        path.push("registry");
+        path.push("index");
+        path.push(dir);
+        Ok(match kind {
+            RegistryKind::Git => Self::Bare(bare_index::Index::from_path_and_url(path, url)?),
+            RegistryKind::SparseHttp => Self::Sparse(sparse_index::Index::from_path_and_url(path, url)),
+        })
+    }
+
+    /// Read a single crate definition from the index, this does not update the index first so
+    /// results may be stale.  (Use `Index::update` if you want to force a global update).
+    pub fn crate_(&self, name: &str) -> Option<Crate> {
+        match self {
+            Self::Sparse(s) => s.crate_from_cache(name),
+            Self::Bare(b) => b.crate_(name),
+        }
+    }
+
+    /// Force a refresh of the crates index from the upstream repository.  Note that this may
+    /// invalidate cache entries as their commit IDs will no longer match.
+    ///
+    /// # TODO
+    ///
+    /// This is a no-op on sparse registries.
+    pub fn update(&mut self) -> Result<(), Error> {
+        match self {
+            Self::Sparse(_s) => Ok(()),
+            Self::Bare(b) => b.update(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,19 +59,22 @@ use std::path::Path;
 use std::sync::Arc;
 
 mod bare_index;
+mod sparse_index;
+mod index;
 mod dedupe;
 mod dirs;
 /// Re-exports in case you want to inspect specific error details
 pub mod error;
-mod sparse_index;
 
 pub use bare_index::Crates;
-pub use bare_index::Index;
+pub use bare_index::Index as BareIndex;
 
 #[doc(hidden)]
 pub use error::CratesIterError;
 pub use error::Error;
 pub use sparse_index::Index as SparseIndex;
+
+pub use index::Index;
 
 /// The default URL of the crates.io index for use with git, see [`Index::with_path`]
 pub static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";


### PR DESCRIPTION
This change adds a new `Index` type that wraps an appropriate index backend (`sparse+http(s)` or `git`) by parsing/interpreting the registry URI.  See #87 and #100 for related issues/progress.  The wrapping `Index` has a restricted API compared to the backends, since it can only sensibly do things that both backends can do (e.g. it's not clear what `tree` would do on a sparse HTTP registry).

As a motivational example, this change drops directly into `cargo-edit` and allows (best-effort) `cargo upgrade` of sparse HTTP registries.

This change doesn't:

1. Change the DEFAULT_CARGO_INDEX to the new sparse index
2. Add support for authenticated HTTP registries
3. Add any support for ensuring that HTTP registry caches are up-to-date when reading crate data (mostly due to the previous two bullets).