### PR TITLE
Update version of `git2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-git2 = { version = "0.16", default-features = false }
+git2 = { version = "0.17", default-features = false }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 memchr = "2.5.0"


### PR DESCRIPTION
This allows using it with crates that depend on a later version, such as rustwide 0.16.0.