### PR TITLE
For 0.20.0: Make git2 dependency optional via new "git-index" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-git2 = { version = ">=0.16, <=0.17", default-features = false }
+git2 = { version = ">=0.16, <=0.17", default-features = false, optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "0.2", optional = true }
@@ -35,7 +35,8 @@ cap = "0.1.2"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["https", "parallel"]
+default = ["git-index", "https", "parallel"]
+git-index = ["git2"]
 https = ["git2/https"]
 parallel = ["dep:rayon"]
 vendored-openssl = ["git2/vendored-openssl"]

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -625,4 +625,29 @@ mod test {
 
         assert!(found_gcc_crate);
     }
+
+    #[test]
+    fn matches_cargo() {
+        assert_eq!(
+            crate::dirs::url_to_local_dir(crate::INDEX_GIT_URL).unwrap(),
+            (
+                "github.com-1ecc6299db9ec823".to_owned(),
+                crate::INDEX_GIT_URL.to_owned()
+            )
+        );
+
+        // Ensure we actually strip off the irrelevant parts of a url, note that
+        // the .git suffix is not part of the canonical url, but *is* used when hashing
+        assert_eq!(
+            crate::dirs::url_to_local_dir(&format!(
+                "registry+{}.git?one=1&two=2#fragment",
+                crate::INDEX_GIT_URL
+            ))
+            .unwrap(),
+            (
+                "github.com-c786010fb7ef2e6e".to_owned(),
+                crate::INDEX_GIT_URL.to_owned()
+            )
+        );
+    }
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -141,14 +141,6 @@ mod test {
     #[test]
     fn matches_cargo() {
         assert_eq!(
-            super::url_to_local_dir(crate::INDEX_GIT_URL).unwrap(),
-            (
-                "github.com-1ecc6299db9ec823".to_owned(),
-                crate::INDEX_GIT_URL.to_owned()
-            )
-        );
-
-        assert_eq!(
             super::url_to_local_dir(crate::CRATES_IO_HTTP_INDEX).unwrap(),
             (
                 "index.crates.io-6f17d22bba15001f".to_owned(),
@@ -167,20 +159,6 @@ mod test {
             (
                 "dl.cloudsmith.io-ff79e51ddd2b38fd".to_owned(),
                 "https://dl.cloudsmith.io/aBcW1234aBcW1234/embark/rust/cargo/index.git".to_owned()
-            )
-        );
-
-        // Ensure we actually strip off the irrelevant parts of a url, note that
-        // the .git suffix is not part of the canonical url, but *is* used when hashing
-        assert_eq!(
-            super::url_to_local_dir(&format!(
-                "registry+{}.git?one=1&two=2#fragment",
-                crate::INDEX_GIT_URL
-            ))
-            .unwrap(),
-            (
-                "github.com-c786010fb7ef2e6e".to_owned(),
-                crate::INDEX_GIT_URL.to_owned()
             )
         );
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "git-index")]
 pub use git2::Error as GitError;
 pub use serde_json::Error as SerdeJsonError;
 use std::{fmt, io};
@@ -7,6 +8,7 @@ pub use toml::de::Error as TomlDeError;
 #[derive(Debug)]
 pub enum Error {
     /// git2 library failed. If problems persist, delete `~/.cargo/registry`
+    #[cfg(feature = "git-index")]
     Git(GitError),
     /// `Index::from_url` got a bogus URL
     Url(String),
@@ -22,6 +24,7 @@ impl fmt::Display for Error {
     #[cold]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "git-index")]
             Self::Git(e) => fmt::Display::fmt(&e, f),
             Self::Url(u) => f.write_str(u),
             Self::Io(e) => fmt::Display::fmt(&e, f),
@@ -35,6 +38,7 @@ impl std::error::Error for Error {
     #[cold]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            #[cfg(feature = "git-index")]
             Self::Git(e) => Some(e),
             Self::Io(e) => Some(e),
             _ => None,
@@ -42,6 +46,7 @@ impl std::error::Error for Error {
     }
 }
 
+#[cfg(feature = "git-index")]
 impl From<GitError> for Error {
     #[cold]
     fn from(e: GitError) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,15 +21,20 @@
 //! ### Getting information about a single crate
 //!
 //! ```rust
+//! # #[cfg(feature = "git-index")]
+//! # {
 //! let index = crates_index::Index::new_cargo_default()?;
 //! let serde_crate = index.crate_("serde").expect("you should handle errors here");
 //! println!("Serde is at v{}", serde_crate.highest_normal_version().unwrap().version());
 //! # Ok::<_, crates_index::Error>(())
+//! # }
 //! ```
 //!
 //! ### Iterating over *all* crates in the index
 //!
 //! ```rust
+//! # #[cfg(feature = "git-index")]
+//! # {
 //! let index = crates_index::Index::new_cargo_default()?;
 //! for crate_ in index.crates() {
 //!    let latest = crate_.most_recent_version();
@@ -44,6 +49,7 @@
 //! });
 //!
 //! # Ok::<_, crates_index::Error>(())
+//! # }
 //! ```
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -57,6 +63,7 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
+#[cfg(feature = "git-index")]
 mod bare_index;
 mod config;
 mod dedupe;
@@ -65,8 +72,11 @@ mod dirs;
 pub mod error;
 mod sparse_index;
 
+#[cfg(feature = "git-index")]
 pub use bare_index::Crates;
+#[cfg(feature = "git-index")]
 pub use bare_index::Index;
+#[cfg(feature = "git-index")]
 pub use bare_index::INDEX_GIT_URL;
 
 pub use dirs::get_index_details;

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -5,7 +5,7 @@ use std::alloc;
 static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
 
 #[test]
-#[cfg(feature = "parallel")]
+#[cfg(all(feature = "parallel", features = "git-index"))]
 fn mem_usage() {
     use crates_index::Index;
     use rayon::iter::ParallelIterator;


### PR DESCRIPTION
To adapt to the sparse crates.io index, I [have stopped](https://github.com/Enselic/cargo-public-api/pull/439) using the git index code from crates-index, and only use the `Crate` code, in particular [`Crate::from_slice`](https://docs.rs/crates-index/0.19.10/crates_index/struct.Crate.html#method.from_slice), since that works with the HTTP response of the sparse index:

```
$ curl https://index.crates.io/ex/am/example_api
{"name":"example_api","vers":"0.1.0","deps":[],"cksum":"d0f99c425515721620183a74993ebb809ca7f06c4e6b09b8c28668d56a2e78fd","features":{},"yanked":false}
{"name":"example_api","vers":"0.1.1","deps":[],"cksum":"3fc31d0e953c46287ea7ddb2f5cd93f0b8eae0ec9777f75569b9d3b7837c14bc","features":{},"yanked":false}
{"name":"example_api","vers":"0.2.0","deps":[],"cksum":"67c4a4db10e5e11217344e754b634eab454ee983a3123c576a2781baefc08bc8","features":{},"yanked":false}
{"name":"example_api","vers":"0.3.0","deps":[],"cksum":"8933479dd187e1d4d7de03e4dfd67e23d3ca494da830d1718710c779b5bd2156","features":{},"yanked":false}
{"name":"example_api","vers":"0.2.1","deps":[],"cksum":"2cb9ebe24cd5cdf18d63dd22cbc85fc6ad94aa10645038e8cfebead34186aaff","features":{"feature":[]},"yanked":false}
```

This means that I do not need the git2 dep at all. This PR makes the git2 dep of crates-index optional (but default).

In [my project](https://github.com/Enselic/cargo-public-api/pull/446) this reduces number of deps from 151 to 134 and reduces release build time from 260s to 190s, so the gain is quite substantial.

To reduce the number of `#[cfg(feature = "git-index")]` I had to add, I had to move the code around a bit, but not in a way that changes the public API:

```console
$ cargo install cargo-public-api --locked
$ cargo public-api diff origin/master..optional-git-index
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
(none)
```

Related: #87 

