### PR TITLE
Increase threshold in mem_usage() test from 6000 to 6200

### DIFF
--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -22,5 +22,5 @@ fn mem_usage() {
         all_crates.len(),
         used / all_crates.len()
     );
-    assert!(used / all_crates.len() < 6000);
+    assert!(used / all_crates.len() < 6200);
 }


### PR DESCRIPTION
Reported mem usage both locally and in CI is ~6080 bytes which makes the test fail. Increase threshold from 6000 to 6200 bytes to fix CI.

Other PRs' CI fails because of this,  e.g.
* #107 
* #109
