### PR TITLE
Fix hash calculation on 32-bit targets

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -32,7 +32,7 @@ pub(crate) fn url_to_local_dir(url: &str) -> Result<(String, String), Error> {
     }
 
     #[allow(deprecated)]
-    fn hash_u64(url: &str, registry_kind: usize) -> u64 {
+    fn hash_u64(url: &str, registry_kind: u64) -> u64 {
         use std::hash::{Hash, Hasher, SipHasher};
 
         let mut hasher = SipHasher::new_with_keys(0, 0);


### PR DESCRIPTION
While doing another PR I noticed this bug in the hash calculation used to find the local index directory for a registry, the use of usize would result in different hashes on 32-bit architectures. Apparently this is not an issue since no one has complained AFAICT, but might as well fix it to potentially save some pain in the future.

See https://github.com/EmbarkStudios/cargo-deny/pull/374