### PR TITLE
Cleanup sparse index support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ toml = "0.7.3"
 [dev-dependencies]
 tempfile = "3.5.0"
 cap = "0.1.2"
+reqwest = { version = "0.11", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+    "gzip",
+] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -230,7 +230,7 @@ impl Index {
             cache_path.push(".cache");
             cache_path.push(&rel_path);
             if let Ok(cache_bytes) = std::fs::read(&cache_path) {
-                if let Ok(krate) = Crate::from_cache_slice(&cache_bytes, &self.head_str) {
+                if let Ok(krate) = Crate::from_cache_slice(&cache_bytes, Some(&self.head_str)) {
                     return Some(krate);
                 }
             }

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -182,7 +182,7 @@ impl Index {
     /// to read majority of crates, prefer the [`Index::crates()`] iterator.
     #[must_use]
     pub fn crate_(&self, name: &str) -> Option<Crate> {
-        let rel_path = crate::crate_name_to_relative_path(name)?;
+        let rel_path = crate::crate_name_to_relative_path(name, std::path::MAIN_SEPARATOR)?;
 
         // Attempt to load the .cache/ entry first, this is purely an acceleration
         // mechanism and can fail for a few reasons that are non-fatal

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -409,10 +409,10 @@ impl<'a> Iterator for Crates<'a> {
 
 #[cfg(test)]
 mod test {
+    use super::Index;
     #[test]
+    #[ignore]
     fn bare_iterator() {
-        use super::Index;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
@@ -436,14 +436,13 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn clones_bare_index() {
-        use super::Index;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let path = tmp_dir.path().join("some/sub/dir/testing/abc");
 
-        let mut repo = Index::with_path(path, crate::INDEX_GIT_URL)
-            .expect("Failed to clone crates.io index");
+        let mut repo =
+            Index::with_path(path, crate::INDEX_GIT_URL).expect("Failed to clone crates.io index");
 
         fn test_sval(repo: &Index) {
             let krate = repo
@@ -478,9 +477,8 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn opens_bare_index() {
-        use super::Index;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let mut repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
@@ -519,9 +517,87 @@ mod test {
     }
 
     #[test]
-    fn reads_replaced_source() {
-        use super::Index;
+    #[ignore]
+    fn test_cargo_default_updates() {
+        let mut index = Index::new_cargo_default().unwrap();
+        index
+            .update()
+            .map_err(|e| {
+                format!(
+                    "could not fetch cargo's index in {}: {}",
+                    index.path().display(),
+                    e
+                )
+            })
+            .unwrap();
+        assert!(index.crate_("crates-index").is_some());
+        assert!(index.crate_("toml").is_some());
+        assert!(index.crate_("gcc").is_some());
+        assert!(index.crate_("cc").is_some());
+        assert!(index.crate_("CC").is_some());
+        assert!(index.crate_("無").is_none());
+    }
 
+    #[test]
+    #[ignore]
+    fn test_dependencies() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let index = Index::with_path(tmp_dir.path(), crate::INDEX_GIT_URL).unwrap();
+
+        let crate_ = index
+            .crate_("sval")
+            .expect("Could not find the crate libnotify in the index");
+        let _ = format!("supports debug {crate_:?}");
+
+        let version = crate_
+            .versions()
+            .iter()
+            .find(|v| v.version() == "0.0.1")
+            .expect("Version 0.0.1 of sval does not exist?");
+        let dep_with_package_name = version
+            .dependencies()
+            .iter()
+            .find(|d| d.name() == "serde_lib")
+            .expect("sval does not have expected dependency?");
+        assert_ne!(
+            dep_with_package_name.name(),
+            dep_with_package_name.package().unwrap()
+        );
+        assert_eq!(
+            dep_with_package_name.crate_name(),
+            dep_with_package_name.package().unwrap()
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn test_can_parse_all() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let mut found_gcc_crate = false;
+
+        let index = Index::with_path(tmp_dir.path(), crate::INDEX_GIT_URL).unwrap();
+        let mut ctx = crate::DedupeContext::new();
+
+        for c in index.crates_refs().unwrap() {
+            if c.as_slice().map_or(false, |blob| blob.is_empty()) {
+                continue; // https://github.com/rust-lang/crates.io/issues/6159
+            }
+            match c.parse(&mut ctx) {
+                Ok(c) => {
+                    if c.name() == "gcc" {
+                        found_gcc_crate = true;
+                    }
+                }
+                Err(e) => panic!("can't parse :( {c:?}: {e}"),
+            }
+        }
+
+        assert!(found_gcc_crate);
+    }
+
+    #[test]
+    #[ignore]
+    fn reads_replaced_source() {
         let index = Index::new_cargo_default();
         assert!(index.is_ok());
         assert!(index.unwrap().index_config().is_ok());

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -6,29 +6,8 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-/// https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
-fn find_cargo_config() -> Option<PathBuf> {
-    if let Ok(current) = std::env::current_dir() {
-        let mut base = current;
-        loop {
-            let mut path = base.join(".cargo");
-            path.push("config.toml");
-            if path.exists() {
-                return Some(path);
-            }
-            if !base.pop() {
-                break;
-            }
-        }
-    }
-    if let Ok(home) = home::cargo_home() {
-        let path = home.join("config.toml");
-        if path.exists() {
-            return Some(path);
-        }
-    }
-    None
-}
+/// The default URL of the crates.io index for use with git, see [`Index::with_path`]
+pub const INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
 /// Wrapper around managing the crates.io-index git repository
 ///

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -188,7 +188,8 @@ impl Index {
         // mechanism and can fail for a few reasons that are non-fatal
         {
             // avoid realloc on each push
-            let mut cache_path = PathBuf::with_capacity(path_max_byte_len(&self.path) + 8 + rel_path.len());
+            let mut cache_path =
+                PathBuf::with_capacity(path_max_byte_len(&self.path) + 8 + rel_path.len());
             cache_path.push(&self.path);
             cache_path.push(".cache");
             cache_path.push(&rel_path);
@@ -232,8 +233,11 @@ impl Index {
     ///
     /// This method is available only if the "parallel" feature is enabled.
     #[cfg(feature = "parallel")]
-    #[must_use] pub fn crates_parallel(&self) -> impl rayon::iter::ParallelIterator<Item=Result<Crate, CratesIterError>> + '_ {
-        use rayon::iter::{IntoParallelIterator, ParallelIterator, IndexedParallelIterator};
+    #[must_use]
+    pub fn crates_parallel(
+        &self,
+    ) -> impl rayon::iter::ParallelIterator<Item = Result<Crate, CratesIterError>> + '_ {
+        use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
         let tree_oids = match self.crates_top_level_refs() {
             Ok(objs) => objs.into_iter().map(|obj| obj.id()).collect::<Vec<_>>(),
@@ -242,7 +246,8 @@ impl Index {
 
         let path = self.repo.path();
 
-        tree_oids.into_par_iter()
+        tree_oids
+            .into_par_iter()
             .with_min_len(64)
             .map_init(
                 move || (Repository::open_bare(path), DedupeContext::new()),
@@ -313,7 +318,10 @@ impl Index {
             })
             .map_err(|e| {
                 // TODO: The Error enum lacks a proper variant for this case
-                Error::Url(format!("The repo at path {} is unusable due to having an invalid HEAD reference: {e}", path.display()))
+                Error::Url(format!(
+                    "The repo at path {} is unusable due to having an invalid HEAD reference: {e}",
+                    path.display()
+                ))
             })
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,130 @@
+use std::io::{Error, ErrorKind, Result};
+
+pub(crate) const CURRENT_CACHE_VERSION: u8 = 3;
+pub(crate) const CURRENT_INDEX_FORMAT_VERSION: u32 = 2;
+
+impl crate::Crate {
+    /// Parse crate index entry from a .cache file, this can fail for a number of reasons
+    ///
+    /// 1. There is no entry for this crate
+    /// 2. The entry was created with an older version than the one specified
+    /// 3. The entry is a newer version than what can be read, would only
+    /// happen if a future version of cargo changed the format of the cache entries
+    /// 4. The cache entry is malformed somehow
+    #[inline(never)]
+    pub(crate) fn from_cache_slice(bytes: &[u8], index_version: Option<&str>) -> Result<Self> {
+        // See src/cargo/sources/registry/index.rs
+        let (first_byte, mut rest) = bytes.split_first().ok_or(ErrorKind::UnexpectedEof)?;
+
+        match *first_byte {
+            // This is the current 1.54.0 - 1.70.0+ version of cache entries
+            CURRENT_CACHE_VERSION => {
+                let index_v_bytes = rest.get(..4).ok_or(ErrorKind::UnexpectedEof)?;
+                let index_v = u32::from_le_bytes(index_v_bytes.try_into().unwrap());
+                if index_v != CURRENT_INDEX_FORMAT_VERSION {
+                    return Err(Error::new(ErrorKind::Unsupported,
+                        format!("wrong index format version: {index_v} (expected {CURRENT_INDEX_FORMAT_VERSION}))")));
+                }
+                rest = &rest[4..];
+            }
+            // This is only to support ancient <1.52.0 versions of cargo https://github.com/rust-lang/cargo/pull/9161
+            1 => {}
+            // Note that the change from 2 -> 3 was only to invalidate cache
+            // entries https://github.com/rust-lang/cargo/pull/9476 and
+            // version 2 entries should only be emitted by cargo 1.52.0 and 1.53.0,
+            // but rather than _potentially_ parse bad cache entries as noted in
+            // the PR we explicitly tell the user their version of cargo is suspect
+            // these versions are so old (and specific) it shouldn't affect really anyone
+            2 => {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "potentially invalid version 2 cache entry found",
+                ));
+            }
+            version => {
+                return Err(Error::new(
+                    ErrorKind::Unsupported,
+                    format!("cache version '{version}' not currently supported"),
+                ));
+            }
+        }
+
+        let mut iter = split(rest, 0);
+        let update = iter.next().ok_or(ErrorKind::UnexpectedEof)?;
+        if let Some(index_version) = index_version {
+            if update != index_version.as_bytes() {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "cache out of date: current index ({index_version}) != cache ({})",
+                        String::from_utf8_lossy(update)
+                    ),
+                ));
+            }
+        }
+
+        Self::from_version_entries_iter(iter)
+    }
+
+    pub(crate) fn from_version_entries_iter<'a, I: Iterator<Item = &'a [u8]> + 'a>(
+        mut iter: I,
+    ) -> Result<Self> {
+        let mut versions = Vec::new();
+
+        // Each entry is a tuple of (semver, version_json)
+        while let Some(_version) = iter.next() {
+            let version_slice = iter.next().ok_or(ErrorKind::UnexpectedEof)?;
+            let version: crate::Version = serde_json::from_slice(version_slice)
+                .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+            versions.push(version);
+        }
+
+        Ok(Self {
+            versions: versions.into_boxed_slice(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn write_to_file(&self, version: &str, path: &std::path::Path) {
+        let mut v = Vec::new();
+        v.push(CURRENT_CACHE_VERSION);
+        v.extend_from_slice(&CURRENT_INDEX_FORMAT_VERSION.to_le_bytes());
+        v.extend_from_slice(version.as_bytes());
+        v.push(0);
+
+        for version in self.versions() {
+            v.extend_from_slice(version.version().as_bytes());
+            v.push(0);
+            v.append(&mut serde_json::to_vec(version).unwrap());
+            v.push(0);
+        }
+
+        std::fs::write(path, v).unwrap();
+    }
+}
+
+pub(crate) fn split(haystack: &[u8], needle: u8) -> impl Iterator<Item = &[u8]> + '_ {
+    struct Split<'a> {
+        haystack: &'a [u8],
+        needle: u8,
+    }
+
+    impl<'a> Iterator for Split<'a> {
+        type Item = &'a [u8];
+
+        #[inline]
+        fn next(&mut self) -> Option<&'a [u8]> {
+            if self.haystack.is_empty() {
+                return None;
+            }
+            let (ret, remaining) = match memchr::memchr(self.needle, self.haystack) {
+                Some(pos) => (&self.haystack[..pos], &self.haystack[pos + 1..]),
+                None => (self.haystack, &[][..]),
+            };
+            self.haystack = remaining;
+            Some(ret)
+        }
+    }
+
+    Split { haystack, needle }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,77 @@
+use crate::Error;
+use std::path::{Path, PathBuf};
+
+/// Calls the specified function for each cargo config located according to
+/// cargo's standard hierarchical structure
+///
+/// Note that this only supports the use of `.cargo/config.toml`, which is not
+/// supported below cargo 1.39.0
+///
+/// See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+pub(crate) fn read_cargo_config<T>(
+    root: Option<&Path>,
+    cargo_home: Option<&Path>,
+    callback: impl Fn(&toml::Value) -> Option<T>,
+) -> Result<Option<T>, Error> {
+    use std::borrow::Cow;
+
+    if let Some(mut path) = root
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
+    {
+        loop {
+            path.push(".cargo/config.toml");
+            if path.exists() {
+                let toml: toml::Value =
+                    toml::from_str(&std::fs::read_to_string(&path)?).map_err(Error::Toml)?;
+                if let Some(value) = callback(&toml) {
+                    return Ok(Some(value));
+                }
+            }
+            path.pop();
+            path.pop();
+
+            // Walk up to the next potential config root
+            if !path.pop() {
+                break;
+            }
+        }
+    }
+
+    if let Some(home) = cargo_home
+        .map(Cow::Borrowed)
+        .or_else(|| home::cargo_home().ok().map(Cow::Owned))
+    {
+        let path = home.join("config.toml");
+        if path.exists() {
+            let toml: toml::Value =
+                toml::from_str(&std::fs::read_to_string(&path)?).map_err(Error::Toml)?;
+            if let Some(value) = callback(&toml) {
+                return Ok(Some(value));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Gets the url of a replacement registry for crates.io if one has been configured
+///
+/// See https://doc.rust-lang.org/cargo/reference/source-replacement.html
+#[inline]
+pub(crate) fn get_crates_io_replacement(
+    root: Option<&Path>,
+    cargo_home: Option<&Path>,
+) -> Result<Option<String>, Error> {
+    read_cargo_config(root, cargo_home, |config| {
+        config.get("source").and_then(|sources| {
+            sources
+                .get("crates-io")
+                .and_then(|v| v.get("replace-with"))
+                .and_then(|v| v.as_str())
+                .and_then(|v| sources.get(v))
+                .and_then(|v| v.get("registry"))
+                .and_then(|v| v.as_str().map(String::from))
+        })
+    })
+}

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -53,7 +53,7 @@ pub(crate) fn url_to_local_dir(url: &str) -> Result<(String, String), Error> {
             .ok_or_else(|| Error::Url(format!("'{url}' is not a valid url")))?;
 
         let scheme_str = &url[..scheme_ind];
-        if scheme_str == "sparse+https" {
+        if scheme_str.starts_with("sparse+http") {
             registry_kind = 3;
             (url, scheme_ind)
         } else if let Some(ind) = scheme_str.find('+') {
@@ -105,6 +105,25 @@ pub(crate) fn url_to_local_dir(url: &str) -> Result<(String, String), Error> {
     }
 
     Ok((format!("{host}-{ident}"), canonical))
+}
+
+/// Get the disk location of the specified url, as well as its canonical form
+pub fn get_index_details(
+    url: &str,
+    cargo_home: Option<&std::path::Path>,
+) -> Result<(std::path::PathBuf, String), Error> {
+    let (dir_name, canonical_url) = url_to_local_dir(url)?;
+
+    let mut path = match cargo_home {
+        Some(path) => path.to_owned(),
+        None => home::cargo_home()?,
+    };
+
+    path.push("registry");
+    path.push("index");
+    path.push(dir_name);
+
+    Ok((path, canonical_url))
 }
 
 #[cfg(test)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,193 @@
+use crate::{config, dirs, Error, Index, SparseIndex};
+use std::{io, path::Path};
+
+/// A unified interface to either a git or sparse HTTP registry index
+pub enum RegistryIndex {
+    /// The (formerly as of 1.70.0) standard git based registry index
+    Git(Index),
+    /// An HTTP sparse index
+    Sparse(SparseIndex),
+}
+
+impl RegistryIndex {
+    /// Opens the default index for crates.io, depending on the configuration and
+    /// version of cargo
+    ///
+    /// 1. Determines if the crates.io registry has been replaced
+    /// 2. Determines the protocol explicitly configured by the user <https://doc.rust-lang.org/cargo/reference/config.html#registriescrates-ioprotocol>
+    /// 3. Detects the version of cargo if not specified and uses that to determine the appropriate default
+    pub fn crates_io(
+        root: Option<&Path>,
+        cargo_home: Option<&Path>,
+        cargo_version: Option<&str>,
+    ) -> Result<Self, Error> {
+        // If the crates.io registry has been replaced it doesn't matter what
+        // the protocol for it has been changed to
+        if let Some(replacement) = config::get_crates_io_replacement(root, cargo_home)? {
+            let (path, canonical) = dirs::get_index_details(&replacement, cargo_home)?;
+
+            return if canonical.starts_with("sparse+http") {
+                Ok(Self::Sparse(SparseIndex::at_path(path, canonical)))
+            } else {
+                Index::with_path(path, canonical).map(Self::Git)
+            };
+        }
+
+        let sparse_index = match std::env::var("CARGO_REGISTRIES_CRATES_IO_PROTOCOL")
+            .ok()
+            .as_deref()
+        {
+            Some("sparse") => true,
+            Some("git") => false,
+            _ => {
+                let sparse_index = config::read_cargo_config(root, cargo_home, |config| {
+                    config
+                        .get("registries")
+                        .and_then(|v| v.get("crates-io"))
+                        .and_then(|v| v.get("protocol"))
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| match v {
+                            "sparse" => Some(true),
+                            "git" => Some(false),
+                            _ => None,
+                        })
+                })?;
+
+                match sparse_index {
+                    Some(si) => si,
+                    None => {
+                        let semver = match cargo_version {
+                            Some(v) => std::borrow::Cow::Borrowed(v),
+                            None => Self::cargo_version()?.into(),
+                        };
+
+                        // Note this would need to change if there was ever a major version
+                        // bump of cargo, but that's unlikely (famous last words)
+                        let minor = semver.split('.').nth(1).ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "cargo semver was in an invalid format",
+                            )
+                        })?;
+
+                        let minor: u32 = minor
+                            .parse()
+                            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+                        minor >= 70
+                    }
+                }
+            }
+        };
+
+        let url = if sparse_index {
+            crate::CRATES_IO_HTTP_INDEX
+        } else {
+            crate::INDEX_GIT_URL
+        };
+
+        let (path, canonical) = dirs::get_index_details(url, cargo_home)?;
+
+        if sparse_index {
+            Ok(Self::Sparse(SparseIndex::at_path(path, canonical)))
+        } else {
+            Index::with_path(path, canonical).map(Self::Git)
+        }
+    }
+
+    /// Retrieves the current version of cargo being used
+    pub fn cargo_version() -> Result<String, Error> {
+        let mut cargo = std::process::Command::new(
+            std::env::var_os("CARGO")
+                .as_deref()
+                .unwrap_or_else(|| std::ffi::OsStr::new("cargo")),
+        );
+
+        cargo.arg("-V");
+        cargo.stdout(std::process::Stdio::piped());
+
+        let output = cargo.output()?;
+        if !output.status.success() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to request cargo version information",
+            )
+            .into());
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+        let semver = stdout.split(' ').nth(1).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cargo version information was in an invalid format",
+            )
+        })?;
+
+        Ok(semver.to_owned())
+    }
+
+    /// Retrieves the index metadata for the specified crate name
+    #[inline]
+    pub fn krate(&self, name: &str) -> Result<crate::Crate, Error> {
+        match self {
+            Self::Git(index) => index.crate_(name).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("unable to locate crate '{name}'"),
+                )
+                .into()
+            }),
+            Self::Sparse(index) => index.crate_from_cache(name),
+        }
+    }
+
+    /// If using the sparse index, returns the url that can be used to fetch
+    /// the index entry for the specified crate
+    #[inline]
+    pub fn crate_url(&self, name: &str) -> Option<String> {
+        // MSRV is 1.60.0 :(
+        //let Self::Sparse(index) = self else { return None; };
+        match self {
+            Self::Git(_) => None,
+            Self::Sparse(index) => index.crate_url(name),
+        }
+    }
+}
+
+impl From<Index> for RegistryIndex {
+    #[inline]
+    fn from(index: Index) -> Self {
+        Self::Git(index)
+    }
+}
+
+impl From<SparseIndex> for RegistryIndex {
+    #[inline]
+    fn from(index: SparseIndex) -> Self {
+        Self::Sparse(index)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::RegistryIndex;
+
+    // Current stable is 1.70.0, and CI only runs beta and nightly, so...just assume
+    // this is fine. If this tests fail you are running an old cargo :(
+
+    #[test]
+    fn gets_cargo_version() {
+        assert!(RegistryIndex::cargo_version().unwrap().as_str() >= "1.70.0");
+    }
+
+    #[test]
+    fn opens_sparse() {
+        assert!(std::env::var_os("CARGO_REGISTRIES_CRATES_IO_PROTOCOL").is_none());
+        assert!(matches!(
+            RegistryIndex::crates_io(None, None, None).unwrap(),
+            RegistryIndex::Sparse(_)
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ use std::sync::Arc;
 
 mod bare_index;
 mod cache;
+mod config;
 mod dedupe;
 mod dirs;
 /// Re-exports in case you want to inspect specific error details
@@ -70,6 +71,8 @@ mod sparse_index;
 pub use bare_index::Crates;
 pub use bare_index::Index;
 pub use bare_index::INDEX_GIT_URL;
+
+pub use dirs::get_index_details;
 
 #[doc(hidden)]
 pub use error::CratesIterError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,11 +356,16 @@ fn crate_prefix(accumulator: &mut String, crate_name: &str, separator: char) -> 
     Some(())
 }
 
-fn crate_name_to_relative_path(crate_name: &str) -> Option<String> {
+fn crate_name_to_relative_path(crate_name: &str, separator: char) -> Option<String> {
     let mut rel_path = String::with_capacity(crate_name.len() + 6);
-    crate_prefix(&mut rel_path, crate_name, std::path::MAIN_SEPARATOR)?;
-    rel_path.push(std::path::MAIN_SEPARATOR);
-    rel_path.extend(crate_name.as_bytes().iter().map(|c| c.to_ascii_lowercase() as char));
+    crate_prefix(&mut rel_path, crate_name, separator)?;
+    rel_path.push(separator);
+    rel_path.extend(
+        crate_name
+            .as_bytes()
+            .iter()
+            .map(|c| c.to_ascii_lowercase() as char),
+    );
 
     Some(rel_path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod dedupe;
 mod dirs;
 /// Re-exports in case you want to inspect specific error details
 pub mod error;
+mod index;
 mod sparse_index;
 
 pub use bare_index::Crates;
@@ -77,6 +78,7 @@ pub use dirs::get_index_details;
 #[doc(hidden)]
 pub use error::CratesIterError;
 pub use error::Error;
+pub use index::RegistryIndex;
 pub use sparse_index::Index as SparseIndex;
 pub use sparse_index::CRATES_IO_HTTP_INDEX;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,14 +69,13 @@ mod sparse_index;
 
 pub use bare_index::Crates;
 pub use bare_index::Index;
+pub use bare_index::INDEX_GIT_URL;
 
 #[doc(hidden)]
 pub use error::CratesIterError;
 pub use error::Error;
 pub use sparse_index::Index as SparseIndex;
-
-/// The default URL of the crates.io index for use with git, see [`Index::with_path`]
-pub static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
+pub use sparse_index::CRATES_IO_HTTP_INDEX;
 
 /// A single version of a crate (package) published to the index
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,12 +345,30 @@ fn crate_prefix(accumulator: &mut String, crate_name: &str, separator: char) -> 
         3 => {
             accumulator.push('3');
             accumulator.push(separator);
-            accumulator.extend(crate_name.as_bytes().get(0..1)?.iter().map(|c| c.to_ascii_lowercase() as char));
+            accumulator.extend(
+                crate_name
+                    .as_bytes()
+                    .get(0..1)?
+                    .iter()
+                    .map(|c| c.to_ascii_lowercase() as char),
+            );
         }
         _ => {
-            accumulator.extend(crate_name.as_bytes().get(0..2)?.iter().map(|c| c.to_ascii_lowercase() as char));
+            accumulator.extend(
+                crate_name
+                    .as_bytes()
+                    .get(0..2)?
+                    .iter()
+                    .map(|c| c.to_ascii_lowercase() as char),
+            );
             accumulator.push(separator);
-            accumulator.extend(crate_name.as_bytes().get(2..4)?.iter().map(|c| c.to_ascii_lowercase() as char));
+            accumulator.extend(
+                crate_name
+                    .as_bytes()
+                    .get(2..4)?
+                    .iter()
+                    .map(|c| c.to_ascii_lowercase() as char),
+            );
         }
     };
     Some(())

--- a/src/sparse_index.rs
+++ b/src/sparse_index.rs
@@ -1,6 +1,8 @@
 use crate::{path_max_byte_len, dirs::url_to_local_dir, Crate, Error, IndexConfig};
 use std::io;
-use std::path::PathBuf;
+
+/// The default URL of the crates.io HTTP index, see [`Index::from_url`] and [`Index::new_cargo_default`]
+pub const CRATES_IO_HTTP_INDEX: &str = "sparse+https://index.crates.io/";
 
 /// Wrapper around managing a sparse HTTP index, re-using Cargo's local disk caches.
 ///

--- a/src/sparse_index.rs
+++ b/src/sparse_index.rs
@@ -75,7 +75,8 @@ impl Index {
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "bad name"))?;
 
         // avoid realloc on each push
-        let mut cache_path = PathBuf::with_capacity(path_max_byte_len(&self.path) + 8 + rel_path.len());
+        let mut cache_path =
+            PathBuf::with_capacity(path_max_byte_len(&self.path) + 8 + rel_path.len());
         cache_path.push(&self.path);
         cache_path.push(".cache");
         cache_path.push(rel_path);

--- a/src/sparse_index.rs
+++ b/src/sparse_index.rs
@@ -42,8 +42,17 @@ impl Index {
         cache_path.push(&self.path);
         cache_path.push(".cache");
         cache_path.push(rel_path);
-        let cache_bytes = std::fs::read(&cache_path)?;
-        Ok(Crate::from_sparse_cache_slice(&cache_bytes)?)
+        let cache_bytes = std::fs::read(&cache_path).map_err(|err| {
+            if err.kind() == io::ErrorKind::NotFound {
+                Error::Io(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    cache_path.to_string_lossy().to_owned(),
+                ))
+            } else {
+                err.into()
+            }
+        })?;
+        Ok(Crate::from_cache_slice(&cache_bytes, None)?)
     }
 }
 

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -7,6 +7,7 @@ use std::alloc;
 static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
 
 #[test]
+#[ignore]
 fn mem_usage() {
     let index = Index::new_cargo_default().unwrap();
 


### PR DESCRIPTION
- Fix hash calculation on 32-bit targets
- Split cache to module
- Move INDEX_GIT_URL, add CRATES_IO_HTTP_INDEX
- Cleanup initialization of indices
- Add SparseIndex::crate_url
- Rustfmt
- Move tests from lib to bare_index
- Add testing with HTTP for sparse index
- Add RegistryIndex

This change kind of grew bigger than I had initially anticipated because I kept finding issues doing the original change, I've tried to split the changes into smaller commits for easier reviewing, but I can open up multiple PRs if that is desired.

## Fixed Bugs
### Git .cache entries have not been read since 1.52.0
Cargo 1.52.0 changed the cache entry version, from 1 -> 2 (it is now 3) which means that this crate has been doing the much more expensive reading from the git blobs rather than (valid) .cache entries for over 2 years. This was fixed by simply combining the git and sparse cache reading into a single function, as the sparse one _was_ correctly reading current 1.54.0+ .cache entries, which are the same regardless of the index type. No one has noticed this because any .cache errors are simply [swallowed](https://github.com/frewsxcv/rust-crates-index/blob/5db087328bc11340c6f6c715ad978d7fc5c9ec69/src/bare_index.rs#L232) by the current code.

### crates.io source replacement was not correct
The [logic](https://github.com/frewsxcv/rust-crates-index/blob/5db087328bc11340c6f6c715ad978d7fc5c9ec69/src/bare_index.rs#L9-L31) for finding whether the crates.io index had been source replaced was incorrect. If _any_ valid config.toml was found, it would be probed for whether the source replacement key was defined, otherwise use the default and move on with initialization. This would mean if you _did_ have source replacement enabled in a config.toml further up the chain, or in CARGO_HOME, it would not be resolved properly. This was resolved by combining the key reading with the hierarchy traversal, so that all valid configs are traversed until the first config that actually defines a valid source replacement is located.

## Changes
### Improved index initialization
While Index does have support for [overriding](https://github.com/frewsxcv/rust-crates-index/blob/5db087328bc11340c6f6c715ad978d7fc5c9ec69/src/bare_index.rs#L93-L95) the disk location, SparseIndex did not, but also there was no middle ground of wanting to override the root CARGO_HOME _without_ setting the actual environment variable, and just having a plain directory missing the canonical directory structure. Retrieving the canonical structure is now possible via `dirs::get_index_details`, consolidating the logic in once place, and making it public for users. This change makes both internal testing (see `sparse_index::test::parses_cache`) and external usage (including testing scenarios) much easier as tests are no longer solely dependent on a global environment variable.

### All git index tests are now ignore
All tests that use the crates.io git index are now marked as `ignore` so that they are not run by default. With 1.70.0 making the sparse index the default both CI and people making contributions to this crate will only be punished from now due to either not having the git index locally, or it being outdated. So the tests are still there, they just need to be explicitly run instead of run by default.

## Additions
### RegistryIndex
This just adds a simple convenience to unify git and sparse indices into a single unit with a single interface. Currently the API between Index and SparseIndex is different (`crate_` vs `crate_from_cache`) which is annoying for downstream usage. It also adds a `crates_io` constructor to easily create the correct default crates.io index depending on the user's environment and current cargo version.

### `SparseIndex::crate_url` + `sparse_index::test::end_to_end`
In _most_ regular scenarios, the sparse index will function relatively equivalently to the git index, however there are some scenarios, particularly pertaining to testing, where there is marked difference between the git index, which, as long as the index has an entry for a particular crate (with or without cache entry) is different from the sparse registry which will only have that cache entry if the crate has been fetched or queried. The `crate_url` allows one to retrieve the url that can be sent a request to get the index entry (if one exists), and the sparse_index::end_to_end` test shows a complete roundtrip of getting the index entry via HTTP, writing it to disk as a .cache entry, and then reading it again.

I personally think it would make sense to use the `http` crate to allow the SparseIndex to both create requests and parse responses that can be sent and received with whatever HTTP client the using code would like to use so that this crate is not tied to any particular HTTP client implementation, but would allow more scenarios where the current difference between the sparse and git index is currently problematic. If that change is welcome I can either add it to this PR or split it out into a follow up PR.