### PR TITLE
Disable rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
[Rustfmt](https://github.com/frewsxcv/rust-crates-index/pull/110#issuecomment-1592098714) is not wanted for this project, so adding this config globally disables it as most users have things like applying rustfmt on save or the like.