### PR TITLE
Add CRATES_IO_HTTP_INDEX

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -6,6 +6,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+/// The default URL of the crates.io index for use with git, see [`Index::with_path`]
+pub const INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
+
 /// https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
 fn find_cargo_config() -> Option<PathBuf> {
     if let Ok(current) = std::env::current_dir() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,14 +68,13 @@ mod sparse_index;
 
 pub use bare_index::Crates;
 pub use bare_index::Index;
+pub use bare_index::INDEX_GIT_URL;
 
 #[doc(hidden)]
 pub use error::CratesIterError;
 pub use error::Error;
 pub use sparse_index::Index as SparseIndex;
-
-/// The default URL of the crates.io index for use with git, see [`Index::with_path`]
-pub static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
+pub use sparse_index::CRATES_IO_HTTP_INDEX;
 
 /// A single version of a crate (package) published to the index
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
- Disable rustfmt
- Add CRATES_IO_HTTP_INDEX

Also moves the git index url to the bare_index for clarity

This also fixes 2 bugs:
1. The SparseIndex::from_url was not validating that the url started with `sparse+`, which is required as it is part of the hash calculation and would result in incorrect disk locations if the user forgot to add that in the url
2. The hash calculation was incorrect, in cargo, only git registries use the hash of the canonicalized url for the ident, all other registry kinds just hash the raw url