### PR TITLE
Cleanup index initialization

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -6,6 +6,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+/// The default URL of the crates.io index for use with git, see [`Index::with_path`]
+pub const INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
+
 /// https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
 fn find_cargo_config() -> Option<PathBuf> {
     if let Ok(current) = std::env::current_dir() {

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -1,5 +1,5 @@
 use crate::dedupe::DedupeContext;
-use crate::dirs::url_to_local_dir;
+use crate::dirs::get_index_details;
 use crate::{error::CratesIterError, path_max_byte_len, Crate, Error, IndexConfig};
 use git2::Repository;
 use std::fmt;
@@ -57,6 +57,8 @@ impl Index {
     /// disk location as Cargo itself.
     ///
     /// This is the recommended way to access Cargo's index.
+    ///
+    /// Note this function takes the `CARGO_HOME` environment variable into account
     #[inline]
     pub fn new_cargo_default() -> Result<Self, Error> {
         let config: toml::Value;
@@ -81,13 +83,7 @@ impl Index {
     ///
     /// It can be used to access custom registries.
     pub fn from_url(url: &str) -> Result<Self, Error> {
-        let (dir_name, canonical_url) = url_to_local_dir(url)?;
-        let mut path = home::cargo_home()?;
-
-        path.push("registry");
-        path.push("index");
-        path.push(dir_name);
-
+        let (path, canonical_url) = get_index_details(url, None)?;
         Self::from_path_and_url(path, canonical_url)
     }
 

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -113,6 +113,29 @@ pub(crate) fn url_to_local_dir(url: &str) -> Result<(String, String), Error> {
     Ok((format!("{host}-{ident}"), url))
 }
 
+/// Get the disk location of the specified url, as well as its canonical form,
+/// exactly as cargo would
+/// 
+/// `cargo_home` is used to root the directory at specific location, if not
+/// specified `CARGO_HOME` or else the default cargo location is used as the root
+pub fn get_index_details(
+    url: &str,
+    cargo_home: Option<&std::path::Path>,
+) -> Result<(std::path::PathBuf, String), Error> {
+    let (dir_name, canonical_url) = url_to_local_dir(url)?;
+
+    let mut path = match cargo_home {
+        Some(path) => path.to_owned(),
+        None => home::cargo_home()?,
+    };
+
+    path.push("registry");
+    path.push("index");
+    path.push(dir_name);
+
+    Ok((path, canonical_url))
+}
+
 #[cfg(test)]
 mod test {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,14 +68,13 @@ mod sparse_index;
 
 pub use bare_index::Crates;
 pub use bare_index::Index;
+pub use bare_index::INDEX_GIT_URL;
 
 #[doc(hidden)]
 pub use error::CratesIterError;
 pub use error::Error;
 pub use sparse_index::Index as SparseIndex;
-
-/// The default URL of the crates.io index for use with git, see [`Index::with_path`]
-pub static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
+pub use sparse_index::CRATES_IO_HTTP_INDEX;
 
 /// A single version of a crate (package) published to the index
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ pub use bare_index::Crates;
 pub use bare_index::Index;
 pub use bare_index::INDEX_GIT_URL;
 
+pub use dirs::get_index_details;
+
 #[doc(hidden)]
 pub use error::CratesIterError;
 pub use error::Error;

--- a/src/sparse_index.rs
+++ b/src/sparse_index.rs
@@ -1,6 +1,6 @@
-use crate::{path_max_byte_len, dirs::url_to_local_dir, Crate, Error, IndexConfig};
+use crate::{path_max_byte_len, dirs::get_index_details, Crate, Error, IndexConfig};
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The default URL of the crates.io HTTP index, see [`Index::from_url`] and [`Index::new_cargo_default`]
 pub const CRATES_IO_HTTP_INDEX: &str = "sparse+https://index.crates.io/";
@@ -10,26 +10,18 @@ pub const CRATES_IO_HTTP_INDEX: &str = "sparse+https://index.crates.io/";
 /// Currently it only uses local Cargo cache, and does not access the network in any way.
 pub struct Index {
     path: PathBuf,
+    url: String,
 }
 
 impl Index {
-    /// Creates a view over the sparse HTTP index from a provided URL, opening the same location on
-    /// disk that Cargo uses for that registry index's metadata and cache.
+    /// Creates a view over the sparse HTTP index from a provided URL, opening
+    /// the same location on disk that Cargo uses for that registry index's
+    /// metadata and cache.
+    ///
+    /// Note this function takes the `CARGO_HOME` environment variable into account
+    #[inline]
     pub fn from_url(url: &str) -> Result<Self, Error> {
-        // It is required to have the sparse+ scheme modifier for sparse urls as
-        // they are part of the short ident hash calculation done by cargo
-        if !url.starts_with("sparse+http") {
-            return Err(Error::Url(url.to_owned()));
-        }
-
-        let (dir_name, _) = url_to_local_dir(url)?;
-        let mut path = home::cargo_home()?;
-
-        path.push("registry");
-        path.push("index");
-        path.push(dir_name);
-
-        Ok(Self { path })
+        Self::with_path(home::cargo_home()?, url)
     }
 
     /// Creates an index for the default crates.io registry, using the same
@@ -41,6 +33,30 @@ impl Index {
     #[inline]
     pub fn new_cargo_default() -> Result<Self, Error> {
         Self::from_url(CRATES_IO_HTTP_INDEX)
+    }
+
+    /// Creates a view over the sparse HTTP index from the provided URL, rooted
+    /// at the specified location
+    #[inline]
+    pub fn with_path(cargo_home: impl AsRef<Path>, url: impl AsRef<str>) -> Result<Self, Error> {
+        let url = url.as_ref();
+        // It is required to have the sparse+ scheme modifier for sparse urls as
+        // they are part of the short ident hash calculation done by cargo
+        if !url.starts_with("sparse+http") {
+            return Err(Error::Url(url.to_owned()));
+        }
+
+        let (path, url) = get_index_details(url, Some(cargo_home.as_ref()))?;
+        Ok(Self::at_path(path, url))
+    }
+
+    /// Creates a view over the sparse HTTP index at the exact specified path
+    #[inline]
+    pub fn at_path(path: PathBuf, mut url: String) -> Self {
+        if !url.ends_with('/') {
+            url.push('/');
+        }
+        Self { path, url }
     }
 
     /// Get the global configuration of the index.
@@ -65,25 +81,22 @@ impl Index {
         let cache_bytes = std::fs::read(&cache_path)?;
         Ok(Crate::from_sparse_cache_slice(&cache_bytes)?)
     }
+
+    /// The HTTP url of the index
+    #[inline]
+    pub fn url(&self) -> &str {
+        self.url.strip_prefix("sparse+").unwrap_or(&self.url)
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use std::ffi::OsString;
-    use std::path::PathBuf;
-
     #[test]
     fn parses_cache() {
-        let _resetter = EnvVarResetter::set(
-            "CARGO_HOME",
-            PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap())
-                .join("tests")
-                .join("testdata")
-                .join("sparse_registry_cache")
-                .join("cargo_home"),
-        );
-
-        let index = super::Index::from_url(crate::CRATES_IO_HTTP_INDEX).unwrap();
+        let index = super::Index::with_path(
+            std::path::Path::new(&std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests/testdata/sparse_registry_cache/cargo_home"),
+            crate::CRATES_IO_HTTP_INDEX
+        ).unwrap();
 
         let crate_ = index.crate_from_cache("autocfg").unwrap();
 
@@ -91,35 +104,5 @@ mod test {
         assert_eq!(crate_.versions().len(), 13);
         assert_eq!(crate_.earliest_version().version(), "0.0.1");
         assert_eq!(crate_.highest_version().version(), "1.1.0");
-    }
-
-    struct EnvVarResetter {
-        key: OsString,
-        value: Option<OsString>,
-    }
-
-    impl EnvVarResetter {
-        fn set<K: Into<OsString>, V: Into<OsString>>(key: K, value: V) -> EnvVarResetter {
-            let key = key.into();
-            let value = value.into();
-            let old_value = std::env::var_os(&key);
-
-            std::env::set_var(&key, value);
-
-            EnvVarResetter {
-                key,
-                value: old_value,
-            }
-        }
-    }
-
-    impl Drop for EnvVarResetter {
-        fn drop(&mut self) {
-            if let Some(old_value) = self.value.as_ref() {
-                std::env::set_var(&self.key, old_value);
-            } else {
-                std::env::remove_var(&self.key);
-            }
-        }
     }
 }


### PR DESCRIPTION
- Disable rustfmt
- Add CRATES_IO_HTTP_INDEX
- Cleanup index initialization

This exposes a new `get_index_details` function that takes a url and turns it into the disk location, rooted at the optional location or CARGO_HOME/cargo default, as well as the canonicalized url. This also adds `SparseIndex::with_path` which allows a user to easily create a sparse index at the specific location but still with the same layout as cargo and _not_ be dependent on CARGO_HOME. This meant `sparse_index::test::parses_cache` could be drastically simplified to remove the mucking about with environment variables.