### PR TITLE
Fix config parsing

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,77 @@
+use crate::Error;
+use std::path::{Path, PathBuf};
+
+/// Calls the specified function for each cargo config located according to
+/// cargo's standard hierarchical structure
+///
+/// Note that this only supports the use of `.cargo/config.toml`, which is not
+/// supported below cargo 1.39.0
+///
+/// See https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+pub(crate) fn read_cargo_config<T>(
+    root: Option<&Path>,
+    cargo_home: Option<&Path>,
+    callback: impl Fn(&toml::Value) -> Option<T>,
+) -> Result<Option<T>, Error> {
+    use std::borrow::Cow;
+
+    if let Some(mut path) = root
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
+    {
+        loop {
+            path.push(".cargo/config.toml");
+            if path.exists() {
+                let toml: toml::Value =
+                    toml::from_str(&std::fs::read_to_string(&path)?).map_err(Error::Toml)?;
+                if let Some(value) = callback(&toml) {
+                    return Ok(Some(value));
+                }
+            }
+            path.pop();
+            path.pop();
+
+            // Walk up to the next potential config root
+            if !path.pop() {
+                break;
+            }
+        }
+    }
+
+    if let Some(home) = cargo_home
+        .map(Cow::Borrowed)
+        .or_else(|| home::cargo_home().ok().map(Cow::Owned))
+    {
+        let path = home.join("config.toml");
+        if path.exists() {
+            let toml: toml::Value =
+                toml::from_str(&std::fs::read_to_string(&path)?).map_err(Error::Toml)?;
+            if let Some(value) = callback(&toml) {
+                return Ok(Some(value));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Gets the url of a replacement registry for crates.io if one has been configured
+///
+/// See https://doc.rust-lang.org/cargo/reference/source-replacement.html
+#[inline]
+pub(crate) fn get_crates_io_replacement(
+    root: Option<&Path>,
+    cargo_home: Option<&Path>,
+) -> Result<Option<String>, Error> {
+    read_cargo_config(root, cargo_home, |config| {
+        config.get("source").and_then(|sources| {
+            sources
+                .get("crates-io")
+                .and_then(|v| v.get("replace-with"))
+                .and_then(|v| v.as_str())
+                .and_then(|v| sources.get(v))
+                .and_then(|v| v.get("registry"))
+                .and_then(|v| v.as_str().map(String::from))
+        })
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 mod bare_index;
+mod config;
 mod dedupe;
 mod dirs;
 /// Re-exports in case you want to inspect specific error details


### PR DESCRIPTION
- Disable rustfmt
- Fix config parsing

The [logic](https://github.com/frewsxcv/rust-crates-index/blob/5db087328bc11340c6f6c715ad978d7fc5c9ec69/src/bare_index.rs#L9-L31) for finding whether the crates.io index had been source replaced was incorrect. If _any_ valid config.toml was found, it would be probed for whether the source replacement key was defined, otherwise use the default and move on with initialization. This would mean if you _did_ have source replacement enabled in a config.toml further up the chain, or in CARGO_HOME, it would not be resolved properly. This was resolved by combining the key reading with the hierarchy traversal, so that all valid configs are traversed until the first config that actually defines a valid source replacement is located.