### PR TITLE
refactor: Move Index tests to base_index mod

### DIFF
--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -439,10 +439,11 @@ impl<'a> Iterator for Crates<'a> {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+    use tempfile::TempDir;
+
     #[test]
     fn bare_iterator() {
-        use super::Index;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
@@ -467,8 +468,6 @@ mod test {
 
     #[test]
     fn clones_bare_index() {
-        use super::Index;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
         let path = tmp_dir.path().join("some/sub/dir/testing/abc");
 
@@ -509,8 +508,6 @@ mod test {
 
     #[test]
     fn opens_bare_index() {
-        use super::Index;
-
         let tmp_dir = tempfile::TempDir::new().unwrap();
 
         let mut repo = Index::with_path(tmp_dir.path().to_owned(), crate::INDEX_GIT_URL)
@@ -550,9 +547,82 @@ mod test {
 
     #[test]
     fn reads_replaced_source() {
-        use super::Index;
-
         let index = Index::new_cargo_default();
         assert!(index.unwrap().index_config().is_ok());
+    }
+
+    #[test]
+    fn test_dependencies() {
+        let index = Index::new_cargo_default().unwrap();
+
+        let crate_ = index
+            .crate_("sval")
+            .expect("Could not find the crate libnotify in the index");
+        let _ = format!("supports debug {crate_:?}");
+
+        let version = crate_
+            .versions()
+            .iter()
+            .find(|v| v.version() == "0.0.1")
+            .expect("Version 0.0.1 of sval does not exist?");
+        let dep_with_package_name = version
+            .dependencies()
+            .iter()
+            .find(|d| d.name() == "serde_lib")
+            .expect("sval does not have expected dependency?");
+        assert_ne!(
+            dep_with_package_name.name(),
+            dep_with_package_name.package().unwrap()
+        );
+        assert_eq!(
+            dep_with_package_name.crate_name(),
+            dep_with_package_name.package().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_cargo_default_updates() {
+        let mut index = Index::new_cargo_default().unwrap();
+        index
+            .update()
+            .map_err(|e| {
+                format!(
+                    "could not fetch cargo's index in {}: {}",
+                    index.path().display(),
+                    e
+                )
+            })
+            .unwrap();
+        assert!(index.crate_("crates-index").is_some());
+        assert!(index.crate_("toml").is_some());
+        assert!(index.crate_("gcc").is_some());
+        assert!(index.crate_("cc").is_some());
+        assert!(index.crate_("CC").is_some());
+        assert!(index.crate_("無").is_none());
+    }
+
+    #[test]
+    fn test_can_parse_all() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut found_gcc_crate = false;
+
+        let index = Index::with_path(tmp_dir.path(), crate::INDEX_GIT_URL).unwrap();
+        let mut ctx = DedupeContext::new();
+
+        for c in index.crates_refs().unwrap() {
+            if c.as_slice().map_or(false, |blob| blob.is_empty()) {
+                continue; // https://github.com/rust-lang/crates.io/issues/6159
+            }
+            match c.parse(&mut ctx) {
+                Ok(c) => {
+                    if c.name() == "gcc" {
+                        found_gcc_crate = true;
+                    }
+                }
+                Err(e) => panic!("can't parse :( {c:?}: {e}"),
+            }
+        }
+
+        assert!(found_gcc_crate);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,7 +646,6 @@ fn path_max_byte_len(path: &Path) -> usize {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempfile::TempDir;
 
     #[test]
     fn sizes() {
@@ -663,81 +662,6 @@ mod test {
         assert_eq!(c.most_recent_version().version(), "1.0.1");
         assert_eq!(c.highest_version().version(), "1.2.0-alpha.1");
         assert_eq!(c.highest_normal_version().unwrap().version(), "1.0.1");
-    }
-
-    #[test]
-    fn test_dependencies() {
-        let index = Index::new_cargo_default().unwrap();
-
-        let crate_ = index
-            .crate_("sval")
-            .expect("Could not find the crate libnotify in the index");
-        let _ = format!("supports debug {crate_:?}");
-
-        let version = crate_
-            .versions()
-            .iter()
-            .find(|v| v.version() == "0.0.1")
-            .expect("Version 0.0.1 of sval does not exist?");
-        let dep_with_package_name = version
-            .dependencies()
-            .iter()
-            .find(|d| d.name() == "serde_lib")
-            .expect("sval does not have expected dependency?");
-        assert_ne!(
-            dep_with_package_name.name(),
-            dep_with_package_name.package().unwrap()
-        );
-        assert_eq!(
-            dep_with_package_name.crate_name(),
-            dep_with_package_name.package().unwrap()
-        );
-    }
-
-    #[test]
-    fn test_cargo_default_updates() {
-        let mut index = Index::new_cargo_default().unwrap();
-        index
-            .update()
-            .map_err(|e| {
-                format!(
-                    "could not fetch cargo's index in {}: {}",
-                    index.path().display(),
-                    e
-                )
-            })
-            .unwrap();
-        assert!(index.crate_("crates-index").is_some());
-        assert!(index.crate_("toml").is_some());
-        assert!(index.crate_("gcc").is_some());
-        assert!(index.crate_("cc").is_some());
-        assert!(index.crate_("CC").is_some());
-        assert!(index.crate_("無").is_none());
-    }
-
-    #[test]
-    fn test_can_parse_all() {
-        let tmp_dir = TempDir::new().unwrap();
-        let mut found_gcc_crate = false;
-
-        let index = Index::with_path(tmp_dir.path(), crate::INDEX_GIT_URL).unwrap();
-        let mut ctx = DedupeContext::new();
-
-        for c in index.crates_refs().unwrap() {
-            if c.as_slice().map_or(false, |blob| blob.is_empty()) {
-                continue; // https://github.com/rust-lang/crates.io/issues/6159
-            }
-            match c.parse(&mut ctx) {
-                Ok(c) => {
-                    if c.name() == "gcc" {
-                        found_gcc_crate = true;
-                    }
-                }
-                Err(e) => panic!("can't parse :( {c:?}: {e}"),
-            }
-        }
-
-        assert!(found_gcc_crate);
     }
 
     #[test]


### PR DESCRIPTION
To make it easier to turn git2 into an optional dep.

Continuation of #111 to reduce size of #107.