### PR TITLE
use features2 when using sparse-index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,9 +139,9 @@ impl Version {
         &self.features
     }
 
-    /// combines feature and feature2
+    /// combines features and features2
     ///
-    /// dedups dependencies and features
+    /// dedupes dependencies and features
     fn build_data(&mut self, dedupe: &mut DedupeContext){
         if let Some(features2) = self.features2.take() {
             if let Some(f1) = Arc::get_mut(&mut self.features) {


### PR DESCRIPTION
currently, it seems like when using sparse-index all features in features2 are ignored. 
This PR fixes this and additionally dedupes the data

note:
maybe somebody can think of a better name for `build_data` 