### PR TITLE
Add update_crate to sparse_index.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_derive = "1.0.160"
 serde_json = "1.0.96"
 smol_str = { version = "0.2.0", features = ["serde"] }
 toml = "0.7.3"
+ureq = { version = "2.7.1", features = ["http-interop"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.5.0"
@@ -43,6 +44,7 @@ parallel = ["dep:rayon"]
 vendored-openssl = ["git2/vendored-openssl"]
 ssh = ["git2/ssh"]
 sparse-http = ["dep:http"]
+sparse-ureq = ["dep:ureq", "sparse-http"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/sparse_index.rs
+++ b/src/sparse_index.rs
@@ -108,6 +108,22 @@ impl Index {
         Some(cache_path)
     }
 
+    /// Fetches latest version of the crate from the index and writes the result into the local cache.
+    #[cfg(feature = "sparse-ureq")]
+    pub fn update_crate(&self, name: &str) -> Result<Option<Crate>, Error> {
+        let request: ureq::Request = self.make_cache_request(name)?.into();
+
+        let response: http::Response<String> = request
+            .call()
+            .map_err(|_e| io::Error::new(io::ErrorKind::InvalidInput, "connection error"))?
+            .into();
+
+        let (parts, body) = response.into_parts();
+        let response = http::Response::from_parts(parts, body.into_bytes());
+
+        self.parse_cache_response(name, response, true)
+    }
+
     /// Reads the version of the cache entry for the specified crate, if it exists
     /// 
     /// The version is of the form `key:value`, where, currently, the key is either


### PR DESCRIPTION
This PR adds an update function to the SpraseIndex struct.

this function fetches the latest data from crates.io and stores it in the local sparse-index

### Why ureq
I believe [ureq](https://crates.io/crates/ureq) fits better for this, simply because it has fewer dependencies compared to [reqwest ](https://crates.io/crates/reqwest)and the features of [reqwest ](https://crates.io/crates/reqwest)wouldn't be needed for this.
If somebody needs a more complex API they can still use the lower-level `make_cache_request` and `parse_cache_response` functions.