### PR TITLE
Replace `git2` with `gix`

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features=sparse-http,ssh,changes
+          args: --features=sparse-http,ssh,changes,git-index-performance --release
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features=sparse-http,ssh
+          args: --features=sparse-http,ssh,changes
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _test
 
 # May be created during tests, but should not be present
 tests/testdata/sparse_registry_cache/cargo_home/registry/index/index.crates.io-6f17d22bba15001f/.cache/cr/at/crates-index
+/tests/testdata/git-registry/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ name = "sparse_http_ureq"
 required-features = ["sparse-http"]
 
 [dependencies]
-git2 = { version = "0.17", default-features = false, optional = true }
 gix = { version = "0.49.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
@@ -52,12 +51,11 @@ features = ["sparse-http"]
 [features]
 default = ["git-index", "https", "parallel"]
 changes = ["git-index"]
-git-index = ["dep:git2", "dep:gix"]
+git-index = ["dep:gix"]
 git-index-performance = ["git-index", "gix?/max-performance"]
-https = ["git-index", "git2?/https", "gix?/blocking-http-transport-curl"]
+https = ["git-index", "gix?/blocking-http-transport-curl"]
 parallel = ["dep:rayon"]
-vendored-openssl = ["git-index", "git2/vendored-openssl"]
-ssh = ["git-index", "git2?/ssh"] # at this time, `gix` does not need feature toggles for this as the `ssh` program is used. Native support is planned to match `git2`.
+ssh = ["git-index"] # at this time, `gix` does not need feature toggles for this as the `ssh` program is used. Native support is planned to match `git2`.
 sparse-http = ["dep:http"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,10 @@ smol_str = { version = "0.2.0", features = ["serde"] }
 toml = "0.7.3"
 
 [dev-dependencies]
+bytesize = "1.2.0"
+cap = { version = "0.1.2", features = ["stats"] }
+is_ci = "1.1.1"
 tempfile = "3.5.0"
-cap = "0.1.2"
 ureq = { version = "2.7.1", features = ["http-interop"] }
 reqwest = { version = "0.11.18", features = ["blocking", "gzip"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ required-features = ["sparse-http"]
 
 [dependencies]
 git2 = { version = "0.17", default-features = false, optional = true }
+gix = { version = "0.48.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "0.2", optional = true }
@@ -48,11 +49,11 @@ features = ["sparse-http"]
 [features]
 default = ["git-index", "https", "parallel"]
 changes = ["git-index"]
-git-index = ["dep:git2"]
-https = ["git-index", "git2?/https"]
+git-index = ["dep:git2", "dep:gix"]
+https = ["git-index", "git2?/https", "gix?/blocking-http-transport-curl"]
 parallel = ["dep:rayon"]
-vendored-openssl = ["git-index", "git2?/vendored-openssl"]
-ssh = ["git-index", "git2?/ssh"]
+vendored-openssl = ["git-index", "git2/vendored-openssl"]
+ssh = ["git-index", "git2?/ssh"] # at this time, `gix` does not need feature toggles for this as the `ssh` program is used. Native support is planned to match `git2`.
 sparse-http = ["dep:http"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["sparse-http"]
 
 [dependencies]
 git2 = { version = "0.17", default-features = false, optional = true }
-gix = { version = "0.48.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
+gix = { version = "0.49.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ required-features = ["sparse-http"]
 name = "sparse_http_ureq"
 required-features = ["sparse-http"]
 
+[[example]]
+name = "update_and_get_latest"
+required-features = ["changes"]
+
 [dependencies]
 gix = { version = "0.50.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "sparse_http_ureq"
 required-features = ["sparse-http"]
 
 [dependencies]
-gix = { version = "0.49.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
+gix = { version = "0.50.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0.160", features = ["rc"] }
 serde_derive = "1.0.160"
 serde_json = "1.0.96"
 smol_str = { version = "0.2.0", features = ["serde"] }
+thiserror = "1.0.43"
 toml = "0.7.3"
 
 [dev-dependencies]
@@ -52,6 +53,7 @@ features = ["sparse-http"]
 default = ["git-index", "https", "parallel"]
 changes = ["git-index"]
 git-index = ["dep:git2", "dep:gix"]
+git-index-performance = ["git-index", "gix?/max-performance"]
 https = ["git-index", "git2?/https", "gix?/blocking-http-transport-curl"]
 parallel = ["dep:rayon"]
 vendored-openssl = ["git-index", "git2/vendored-openssl"]

--- a/examples/update_and_get_latest.rs
+++ b/examples/update_and_get_latest.rs
@@ -1,0 +1,14 @@
+//! Updates the local git registry and extracts the latest most recent changes.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut index = crates_index::Index::new_cargo_default()?;
+    println!("Updating index…");
+    index.update()?;
+    
+    let limit = 10;
+    println!("The most recent {limit} changes:\n");
+    for change in index.changes()?.take(limit) {
+        let change = change?;
+        println!("{name} changed in {commit}", name = change.crate_name(), commit = change.commit_hex());
+    }
+    Ok(())
+}

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 #[cfg(feature = "changes")]
 use crate::changes::ChangesIter;
 use crate::dedupe::DedupeContext;
@@ -359,7 +360,7 @@ impl Index {
 
     fn object_at_path(&self, path: PathBuf) -> Result<gix::Object<'_>, GixError> {
         let entry = self.tree()?.lookup_entry_by_path(&path)?
-                        .ok_or_else(|| GixError::PathMissing { path })?;
+                        .ok_or(GixError::PathMissing { path })?;
         Ok(entry.object()?)
     }
     

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -402,8 +402,8 @@ fn clone_url(url: &str, destination: &Path) -> Result<gix::Repository, GixError>
         .configure_remote(|remote| {
             Ok(remote.with_refspecs(
                 [
-                    "HEAD:refs/remotes/origin/HEAD",
-                    "master:refs/remotes/origin/master",
+                    "+HEAD:refs/remotes/origin/HEAD",
+                    "+master:refs/remotes/origin/master",
                 ],
                 gix::remote::Direction::Fetch,
             )?)

--- a/src/bare_index.rs
+++ b/src/bare_index.rs
@@ -478,7 +478,7 @@ impl<'a> Iterator for Crates<'a> {
 
 #[cfg(test)]
 #[cfg(feature = "https")]
-mod test {
+pub(crate)  mod test {
     use super::*;
     use gix::bstr::ByteSlice;
 
@@ -660,7 +660,7 @@ mod test {
         assert!(found_gcc_crate);
     }
 
-    fn shared_index() -> Index {
+    pub(crate) fn shared_index() -> Index {
         let index_path = "tests/testdata/git-registry";
         if is_ci::cached() {
             Index::new_cargo_default()

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -1,10 +1,13 @@
-use crate::bare_index::fetch_opts;
+use crate::bare_index::{fetch_opts, fetch_remote};
 use crate::Error;
 use crate::Index;
 use git2::{Commit, Tree, Oid};
 use std::collections::{VecDeque, HashSet};
 use std::convert::TryInto;
 use std::time::{SystemTime, Duration};
+use gix::bstr::ByteSlice;
+use gix::prelude::TreeEntryRefExt;
+use crate::error::GixError;
 
 const INDEX_GIT_ARCHIVE_URL: &str = "https://github.com/rust-lang/crates.io-index-archive";
 
@@ -14,7 +17,7 @@ pub struct Change {
     crate_name: Box<str>,
     /// Timestamp in the crates.io index repository
     time: SystemTime,
-    commit: Oid,
+    git2_commit: Oid,
 }
 
 impl Change {
@@ -35,21 +38,24 @@ impl Change {
     /// git hash of a commit in the crates.io repository
     #[must_use]
     pub fn commit(&self) -> &[u8; 20] {
-        self.commit.as_bytes().try_into().unwrap()
+        self.git2_commit.as_bytes().try_into().unwrap()
     }
 
     /// git hash of a commit in the crates.io repository
     #[must_use]
     pub fn commit_hex(&self) -> String {
-        self.commit.to_string()
+        self.git2_commit.to_string()
     }
 }
 
 /// See [`Index::changes`]
 pub struct ChangesIter<'repo> {
-    repo: &'repo git2::Repository,
-    current: Commit<'repo>,
-    current_tree: Tree<'repo>,
+    repo: &'repo gix::Repository,
+    git2_repo: &'repo git2::Repository,
+    git2_current: Commit<'repo>,
+    current: gix::Commit<'repo>,
+    git2_current_tree: Tree<'repo>,
+    current_tree: gix::Tree<'repo>,
     out: VecDeque<Change>,
 }
 
@@ -61,10 +67,10 @@ impl<'repo> Iterator for ChangesIter<'repo> {
             let parent = match self.get_parent() {
                 Ok(Some(parent)) => parent,
                 Ok(None) => return None,
-                Err(e) => return Some(Err(e)),
+                Err(e) => return Some(Err(e.into())),
             };
             let parent_tree = parent.tree().ok()?;
-            let time = SystemTime::UNIX_EPOCH + Duration::from_secs(self.current.time().seconds().max(0) as _);
+            let time = SystemTime::UNIX_EPOCH + Duration::from_secs(self.current.time().ok()?.seconds.max(0) as _);
             Self::tree_additions(&self.repo, &mut self.out, time, &self.current.id(), &self.current_tree, &parent_tree).ok()?;
             self.current_tree = parent_tree;
             self.current = parent;
@@ -74,43 +80,71 @@ impl<'repo> Iterator for ChangesIter<'repo> {
 }
 
 impl<'repo> ChangesIter<'repo> {
-    pub(crate) fn new(index: &'repo Index) -> Result<Self, git2::Error> {
-        let current = index.git2_repo.find_object(index.git2_head, None)?.peel_to_commit()?;
+    pub(crate) fn new(index: &'repo Index) -> Result<Self, GixError> {
+        let git2_current = index.git2_repo.find_object(index.git2_head, None).expect("remove me").peel_to_commit().expect("remove me");
+        let current = index.repo.find_object(index.head_commit)?.peel_to_kind(gix::object::Kind::Commit)?.into_commit();
+        let git2_current_tree = git2_current.tree().expect("remove me");
         let current_tree = current.tree()?;
 
         Ok(Self {
-            repo: &index.git2_repo,
+            repo: &index.repo,
+            git2_repo: &index.git2_repo,
             current,
             current_tree,
+            git2_current,
+            git2_current_tree,
             out: VecDeque::new(),
         })
     }
 
-    fn get_parent(&self) -> Result<Option<Commit<'repo>>, Error> {
-        match self.current.parents().next() {
+    fn git2_get_parent(&self) -> Result<Option<Commit<'repo>>, Error> {
+        match self.git2_current.parents().next() {
             Some(ok) => Ok(Some(ok)),
             None => {
-                let (oid, branch) = match oid_and_branch_from_commit_message(self.current.body().unwrap_or_default()) {
+                let (oid, branch) = match git2_oid_and_branch_from_commit_message(self.git2_current.body().unwrap_or_default()) {
                     Some(res) => res,
                     None => return Ok(None),
                 };
-                match self.repo.find_commit(oid) {
+                match self.git2_repo.find_commit(oid) {
                     Ok(ok) => Ok(Some(ok)),
                     Err(_) => {
-                        let mut archive_origin = self.repo.remote_anonymous(INDEX_GIT_ARCHIVE_URL)?;
+                        // TODO: this happens when a history split/squash was detected. 
+                        //       This is only valid for the main index, but let's be sure and use the original URL instead.
+                        let mut archive_origin = self.git2_repo.remote_anonymous(INDEX_GIT_ARCHIVE_URL)?;
                         archive_origin.fetch(
                             &[format!("refs/heads/{}", branch)],
                             Some(&mut fetch_opts()),
                             None,
                         )?;
-                        Ok(Some(self.repo.find_commit(oid)?))
+                        Ok(Some(self.git2_repo.find_commit(oid)?))
+                    },
+                }
+            }
+        }
+    }
+    
+    fn get_parent(&self) -> Result<Option<gix::Commit<'repo>>, GixError> {
+        match self.current.parent_ids().next().map(|id| id.try_object()).transpose()?.flatten() {
+            Some(obj) => Ok(Some(obj.try_into_commit()?)),
+            None => {
+                let msg = self.current.message_raw_sloppy().to_str_lossy();
+                let (oid, branch) = match oid_and_branch_from_commit_message(msg.as_ref()) {
+                    Some(res) => res,
+                    None => return Ok(None),
+                };
+                match self.repo.try_find_object(oid)? {
+                    Some(obj) => Ok(Some(obj.try_into_commit()?)),
+                    None => {
+                        let mut remote = self.repo.remote_at(INDEX_GIT_ARCHIVE_URL)?;
+                        fetch_remote(&mut remote, &[&format!("refs/heads/{}", branch)])?;
+                        Ok(Some(self.repo.find_object(oid)?.try_into_commit()?))
                     },
                 }
             }
         }
     }
 
-    fn tree_additions(repo: &git2::Repository, out: &mut VecDeque<Change>, change_time: SystemTime, commit: &Oid, new: &Tree, old: &Tree) -> Result<(), git2::Error> {
+    fn git2_tree_additions(repo: &git2::Repository, out: &mut VecDeque<Change>, change_time: SystemTime, commit: &Oid, new: &Tree, old: &Tree) -> Result<(), git2::Error> {
         let old_oids = old.iter().map(|old| old.id()).collect::<HashSet<_>>();
         for new_entry in new.iter() {
             let new_id = new_entry.id();
@@ -128,7 +162,7 @@ impl<'repo> ChangesIter<'repo> {
                         Some(t) => t,
                         None => { empty = Self::empty_tree(repo); &empty }
                     };
-                    Self::tree_additions(repo, out, change_time, commit, new_tree, old_tree)?;
+                    Self::git2_tree_additions(repo, out, change_time, commit, new_tree, old_tree)?;
                 } else {
                     if let Some(name) = new_entry.name() {
                         // filter out config.json
@@ -136,10 +170,63 @@ impl<'repo> ChangesIter<'repo> {
                             out.push_back(Change {
                                 time: change_time,
                                 crate_name: name.into(),
-                                commit: commit.clone(),
+                                git2_commit: commit.clone(),
                             });
                         }
                     }
+                }
+            }
+        }
+        Ok(())
+    }
+
+
+    fn tree_additions(
+        repo: &gix::Repository,
+        out: &mut VecDeque<Change>,
+        change_time: SystemTime,
+        commit: &gix::hash::oid,
+        new: &gix::Tree<'_>,
+        old: &gix::Tree<'_>,
+    ) -> Result<(), GixError> {
+        let old_oids = old
+            .iter()
+            .map(|old| old.map(|e| e.object_id()))
+            .collect::<Result<HashSet<_>, _>>()?;
+        let old = old.decode()?;
+        for new_entry in new.iter().filter_map(Result::ok) {
+            if old_oids.contains(new_entry.oid()) { 
+                continue 
+            }
+            if new_entry.mode().is_tree() {
+                let new_tree = new_entry.object()?.into_tree();
+                let name_bytes = new_entry.filename();
+                // Recurse only into crate subdirs, and they all happen to be 1 or 2 letters long
+                let old_obj = if name_bytes.len() <= 2 && name_bytes.iter().copied().all(valid_crate_name_char) {
+                    old.entries.binary_search_by(|entry| entry.filename.cmp(name_bytes))
+                        .ok()
+                        .map(|idx| old.entries[idx].attach(repo))
+                } else {
+                    None
+                }
+                    .map(|o| o.object())
+                    .transpose()?;
+                let old_tree = match old_obj.and_then(|o| o.try_into_tree().ok()) {
+                    Some(t) => t,
+                    None => {
+                        repo.empty_tree()
+                    }
+                };
+                Self::tree_additions(repo, out, change_time, commit, &new_tree, &old_tree)?;
+            } else {
+                let name = new_entry.filename();
+                // filter out config.json
+                if name.iter().copied().all(valid_crate_name_char) {
+                    out.push_back(Change {
+                        time: change_time,
+                        crate_name: name.to_string().into(),
+                        git2_commit: git2::Oid::from_bytes(commit.as_bytes()).expect("valid hash"),
+                    });
                 }
             }
         }
@@ -157,10 +244,20 @@ fn valid_crate_name_char(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'-' || c == b'_'
 }
 
-fn oid_and_branch_from_commit_message(msg: &str) -> Option<(Oid, &str)> {
+fn git2_oid_and_branch_from_commit_message(msg: &str) -> Option<(Oid, &str)> {
     let hash_start = msg.split_once("Previous HEAD was ")?.1.trim_start_matches(|c: char| !c.is_ascii_hexdigit());
     let (hash_str, rest) = hash_start.split_once(|c:char| !c.is_ascii_hexdigit())?;
     let hash = Oid::from_str(hash_str).ok()?;
+    let snapshot_start = rest.find("snapshot-")?;
+    let branch = rest.get(snapshot_start..snapshot_start+"snapshot-xxxx-xx-xx".len())?;
+
+    Some((hash, branch))
+}
+
+fn oid_and_branch_from_commit_message(msg: &str) -> Option<(gix::ObjectId, &str)> {
+    let hash_start = msg.split_once("Previous HEAD was ")?.1.trim_start_matches(|c: char| !c.is_ascii_hexdigit());
+    let (hash_str, rest) = hash_start.split_once(|c:char| !c.is_ascii_hexdigit())?;
+    let hash = gix::ObjectId::from_hex(hash_str.as_bytes()).ok()?;
     let snapshot_start = rest.find("snapshot-")?;
     let branch = rest.get(snapshot_start..snapshot_start+"snapshot-xxxx-xx-xx".len())?;
 
@@ -172,12 +269,16 @@ fn changes() {
     let index = Index::new_cargo_default().unwrap();
     let ch = ChangesIter::new(&index).unwrap();
     let mut last_time = SystemTime::now();
-    for c in ch.take(20) {
+    let desired = 500;
+    let mut count = 0;
+    for c in ch.take(desired) {
         let c = c.unwrap();
+        count += 1;
         index.crate_(&c.crate_name).unwrap();
         assert!(last_time >= c.time);
         last_time = c.time;
     }
+    assert_eq!(count, desired);
 }
 
 #[test]

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -130,14 +130,12 @@ impl<'repo> ChangesIter<'repo> {
             }
             if new_entry.mode().is_tree() {
                 let new_tree = new_entry.object()?.into_tree();
-                let name_bytes = new_entry.filename();
+                let name = new_entry.filename();
                 // Recurse only into crate subdirs, and they all happen to be 1 or 2 letters long
-                let is_crates_subdir = name_bytes.len() <= 2 && name_bytes.iter().copied().all(valid_crate_name_char);
+                let is_crates_subdir = name.len() <= 2 && name.iter().copied().all(valid_crate_name_char);
                 let old_obj = if is_crates_subdir {
-                    old.entries
-                        .binary_search_by(|entry| entry.filename.cmp(name_bytes))
-                        .ok()
-                        .map(|idx| old.entries[idx].attach(repo))
+                    old.bisect_entry(name, true)
+                        .map(|entry| entry.attach(repo))
                 } else {
                     None
                 }

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -75,11 +75,11 @@ impl<'repo> Iterator for ChangesIter<'repo> {
 
 impl<'repo> ChangesIter<'repo> {
     pub(crate) fn new(index: &'repo Index) -> Result<Self, git2::Error> {
-        let current = index.repo.find_object(index.head, None)?.peel_to_commit()?;
+        let current = index.git2_repo.find_object(index.git2_head, None)?.peel_to_commit()?;
         let current_tree = current.tree()?;
 
         Ok(Self {
-            repo: &index.repo,
+            repo: &index.git2_repo,
             current,
             current_tree,
             out: VecDeque::new(),

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -103,7 +103,7 @@ impl<'repo> ChangesIter<'repo> {
                     Some(obj) => Ok(Some(obj.try_into_commit()?)),
                     None => {
                         let mut remote = self.repo.remote_at(INDEX_GIT_ARCHIVE_URL)?;
-                        fetch_remote(&mut remote, &[&format!("refs/heads/{}", branch)])?;
+                        fetch_remote(&mut remote, &[&format!("+refs/heads/{}", branch)])?;
                         Ok(Some(self.repo.find_object(oid)?.try_into_commit()?))
                     }
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,8 @@ impl std::error::Error for Error {
 #[cfg(feature = "git-index")]
 pub enum GixError {
     #[error(transparent)]
+    CreateInMemoryRemote(#[from] gix::remote::init::Error),
+    #[error(transparent)]
     HeadCommit(#[from] gix::reference::head_commit::Error),
     #[error(transparent)]
     TreeOfCommit(#[from] gix::object::commit::Error),
@@ -64,6 +66,8 @@ pub enum GixError {
     DecodeObject(#[from] gix::objs::decode::Error),
     #[error(transparent)]
     FindExistingObject(#[from] gix::object::find::existing::Error),
+    #[error(transparent)]
+    FindObject(#[from] gix::object::find::Error),
     #[error(transparent)]
     IntoObjectKind(#[from] gix::object::try_into::Error),
     #[error("The '{}' file is missing at the root of the tree of the crates index", path.display())]
@@ -86,6 +90,8 @@ pub enum GixError {
     RemoteName(#[from] gix::remote::name::Error),
     #[error(transparent)]
     FetchDuringClone(#[from] gix::clone::fetch::Error),
+    #[error(transparent)]
+    PeelToKind(#[from] gix::object::peel::to_kind::Error),
 }
 
 #[cfg(feature = "git-index")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,11 @@ pub enum GixError {
     #[error(transparent)]
     FindExistingObject(#[from] gix::object::find::existing::Error),
     #[error(transparent)]
-    IntoObjectKind(#[from] gix::object::try_into::Error)
+    IntoObjectKind(#[from] gix::object::try_into::Error),
+    #[error("The '{}' file is missing at the root of the tree of the crates index", path.display())]
+    PathMissing {
+        path: std::path::PathBuf
+    }
 }
 
 #[cfg(feature = "git-index")]
@@ -75,6 +79,14 @@ impl From<Git2Error> for Error {
     #[cold]
     fn from(e: Git2Error) -> Self {
         Self::Git2(e)
+    }
+}
+
+#[cfg(feature = "git-index")]
+impl From<GixError> for Error {
+    #[cold]
+    fn from(e: GixError) -> Self {
+        Self::Git(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,7 +71,15 @@ pub enum GixError {
     #[error("The '{}' file is missing at the root of the tree of the crates index", path.display())]
     PathMissing {
         path: std::path::PathBuf
-    }
+    },
+    #[error(transparent)]
+    LockAcquire(#[from] gix::lock::acquire::Error),
+    #[error(transparent)]
+    PrepareClone(#[from] gix::clone::Error),
+    #[error(transparent)]
+    RemoteName(#[from] gix::remote::name::Error),
+    #[error(transparent)]
+    Fetch(#[from] gix::clone::fetch::Error),
 }
 
 #[cfg(feature = "git-index")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,9 +8,6 @@ pub enum Error {
     /// `gix` crate failed. If problems persist, delete `~/.cargo/registry`
     #[cfg(feature = "git-index")]
     Git(GixError),
-    /// git2 library failed. If problems persist, delete `~/.cargo/registry`
-    #[cfg(feature = "git-index")]
-    Git2(git2::Error),
     /// `Index::from_url` got a bogus URL
     Url(String),
     /// Filesystem error
@@ -27,8 +24,6 @@ impl fmt::Display for Error {
         match self {
             #[cfg(feature = "git-index")]
             Self::Git(e) => fmt::Display::fmt(&e, f),
-            #[cfg(feature = "git-index")]
-            Self::Git2(e) => fmt::Display::fmt(&e, f),
             Self::Url(u) => f.write_str(u),
             Self::Io(e) => fmt::Display::fmt(&e, f),
             Self::Json(e) => fmt::Display::fmt(&e, f),
@@ -43,8 +38,6 @@ impl std::error::Error for Error {
         match self {
             #[cfg(feature = "git-index")]
             Self::Git(e) => Some(e),
-            #[cfg(feature = "git-index")]
-            Self::Git2(e) => Some(e),
             Self::Io(e) => Some(e),
             _ => None,
         }
@@ -92,14 +85,6 @@ pub enum GixError {
     FetchDuringClone(#[from] gix::clone::fetch::Error),
     #[error(transparent)]
     PeelToKind(#[from] gix::object::peel::to_kind::Error),
-}
-
-#[cfg(feature = "git-index")]
-impl From<git2::Error> for Error {
-    #[cold]
-    fn from(e: git2::Error) -> Self {
-        Self::Git2(e)
-    }
 }
 
 #[cfg(feature = "git-index")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 pub use serde_json::Error as SerdeJsonError;
 use std::{fmt, io};
+use std::path::PathBuf;
 pub use toml::de::Error as TomlDeError;
 
 /// Oops
@@ -10,6 +11,15 @@ pub enum Error {
     Git(GixError),
     /// `Index::from_url` got a bogus URL
     Url(String),
+    /// Could not obtain the most recent head commit.
+    MissingHead {
+        /// The references we tried to get commits for.
+        refs_tried: &'static [&'static str],
+        /// The references that were actually present in the repository.
+        refs_available: Vec<String>,
+        /// The path of the repository we tried
+        repo_path: PathBuf,
+    },
     /// Filesystem error
     Io(io::Error),
     /// If this happens, the registry is seriously corrupted. Delete `~/.cargo/registry`.
@@ -24,6 +34,8 @@ impl fmt::Display for Error {
         match self {
             #[cfg(feature = "git-index")]
             Self::Git(e) => fmt::Display::fmt(&e, f),
+            // TODO: switch to thiserror
+            Self::MissingHead{..} => f.write_str("TBD"),
             Self::Url(u) => f.write_str(u),
             Self::Io(e) => fmt::Display::fmt(&e, f),
             Self::Json(e) => fmt::Display::fmt(&e, f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,22 @@
 //! # }
 //! # Ok::<_, crates_index::Error>(())
 //! ```
+//! 
+//! ## Auto-cloning and parallelism
+//! 
+//! When using any means of instantiating the [`Index`] type, we  will 
+//! clone the default crates index (or the given one) if it no git
+//! repository is present at the destination path.
+//! 
+//! In order to protect from parallel operations of this kind, a 
+//! file-based lock is used. When interrupting the program with `Ctrl + C`,
+//! by default the program will be aborted which won't run destructors.
+//! This will cause the file lock to be stranded, causing all future operations
+//! to fail.
+//! 
+//! To prevent this issue, the application must integrate with the
+//! [`gix-tempfile` signal handler](https://docs.rs/gix-tempfile/latest/gix_tempfile/#initial-setup),
+//! which allows locks to be deleted when typical signals are received.
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,12 @@
 //! To prevent this issue, the application must integrate with the
 //! [`gix-tempfile` signal handler](https://docs.rs/gix-tempfile/latest/gix_tempfile/#initial-setup),
 //! which allows locks to be deleted when typical signals are received.
+//!
+//! ## Git Repository Performance
+//!
+//! By default, `gix` is compiled with `max-performance-safe`, which maximizes support for compilation environments but which 
+//! may be slower as it uses a pure-Rust Zlib implementation.
+//! To get best possible performance, use the `git-index-performance` feature toggle.
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
@@ -107,7 +113,7 @@ pub mod error;
 mod sparse_index;
 
 #[cfg(feature = "git-index")]
-pub use bare_index::Crates;
+pub use bare_index::Git2Crates;
 #[cfg(feature = "git-index")]
 pub use bare_index::Index;
 #[cfg(feature = "git-index")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! ### Getting information about a single crate
 //!
 //! ```rust
-//! # #[cfg(feature = "git-index")]
+//! # #[cfg(all(not(debug_assertions), feature = "git-index"))]
 //! # {
 //! let index = crates_index::Index::new_cargo_default()?;
 //! let serde_crate = index.crate_("serde").expect("you should handle errors here");
@@ -33,7 +33,7 @@
 //! ### Iterating over *all* crates in the index
 //!
 //! ```rust
-//! # #[cfg(all(feature = "parallel", feature = "git-index"))]
+//! # #[cfg(all(not(debug_assertions), feature = "parallel", feature = "git-index"))]
 //! # {
 //! let index = crates_index::Index::new_cargo_default()?;
 //! for crate_ in index.crates() {
@@ -113,7 +113,7 @@ pub mod error;
 mod sparse_index;
 
 #[cfg(feature = "git-index")]
-pub use bare_index::Git2Crates;
+pub use bare_index::Crates;
 #[cfg(feature = "git-index")]
 pub use bare_index::Index;
 #[cfg(feature = "git-index")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //!
 //! ### Getting most recently published or yanked crates (enable the `changes` feature!)
 //!
+//! ```rust
 //! # #![cfg(feature = "changes")]
 //! # {
 //! let index = crates_index::Index::new_cargo_default()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,19 @@
 //! By default, `gix` is compiled with `max-performance-safe`, which maximizes support for compilation environments but which 
 //! may be slower as it uses a pure-Rust Zlib implementation.
 //! To get best possible performance, use the `git-index-performance` feature toggle.
+//! 
+//! ## Using `rustls` instead of `openssl` when using the `https` feature in applications
+//! 
+//! When using the `https` feature, a choice will be made for you that involves selecting the `curl` backend for making
+//! the `https` protocol available. As using a different backend isn't additive, as cargo features should be, one will have
+//! to resort to the following.
+//! 
+//! * Change the `crates-index` dependency to not use any default features with `default-features = false`, and turn on
+//!   `features = ["git-index", …(everything else *but* "https")]`
+//! * Add the `gix` dependency with `default-features = false` and `features = ["blocking-http-transport-reqwest-rust-tls"]`.
+//!   Consider renaming the crate to `gix-for-configuration-only = { package = "gix", … }` to make the intend clear.
+//! 
+//! Please note that this should only be done in application manifests, who have the final say over the protocol and backend choices.
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -1,35 +1,38 @@
-use cap::Cap;
-use std::alloc;
-use std::time::Instant;
-use bytesize::ByteSize;
-
-#[global_allocator]
-static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
-
-#[test]
 #[cfg(all(feature = "parallel", feature = "git-index"))]
-fn mem_usage() {
-    use crates_index::Index;
-    use rayon::iter::ParallelIterator;
+mod mem {
+    use cap::Cap;
+    use std::alloc;
+    use std::time::Instant;
+    use bytesize::ByteSize;
 
-    let index = Index::new_cargo_default().unwrap();
+    #[global_allocator]
+    static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
 
-    let before = ALLOCATOR.allocated();
-    // let all_crates: Vec<_> = index.crates().collect();
-    let start = Instant::now();
-    let all_crates: Vec<_> = index.crates_parallel().map(|c| c.unwrap()).collect();
-    let after = ALLOCATOR.allocated();
-    let used = after - before;
-    assert!(all_crates.len() > 89000);
-    let elapsed = start.elapsed().as_secs_f32();
-    let per_crate = used / all_crates.len();
-    eprintln!(
-        "used mem: {}B for {} crates, {}B per crate, took {elapsed:.02}s [total-mem: {total}, peak-mem: {peak}]",
-        ByteSize(used as u64),
-        all_crates.len(),
-        per_crate,
-        total = ByteSize(ALLOCATOR.total_allocated() as u64),
-        peak = ByteSize(ALLOCATOR.max_allocated() as u64),
-    );
-    assert!(per_crate < 6300, "per crate limit {per_crate}B should remain below memory limit");
+    #[test]
+    #[cfg_attr(debug_assertions, ignore = "too slow when running in debug mode")]
+    fn usage() {
+        use crates_index::Index;
+        use rayon::iter::ParallelIterator;
+
+        let index = Index::new_cargo_default().unwrap();
+
+        let before = ALLOCATOR.allocated();
+        // let all_crates: Vec<_> = index.crates().collect();
+        let start = Instant::now();
+        let all_crates: Vec<_> = index.crates_parallel().map(|c| c.unwrap()).collect();
+        let after = ALLOCATOR.allocated();
+        let used = after - before;
+        assert!(all_crates.len() > 89000);
+        let elapsed = start.elapsed().as_secs_f32();
+        let per_crate = used / all_crates.len();
+        eprintln!(
+            "used mem: {}B for {} crates, {}B per crate, took {elapsed:.02}s [total-mem: {total}, peak-mem: {peak}]",
+            ByteSize(used as u64),
+            all_crates.len(),
+            per_crate,
+            total = ByteSize(ALLOCATOR.total_allocated() as u64),
+            peak = ByteSize(ALLOCATOR.max_allocated() as u64),
+        );
+        assert!(per_crate < 6300, "per crate limit {per_crate}B should remain below memory limit");
+    }
 }

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -1,11 +1,13 @@
 use cap::Cap;
 use std::alloc;
+use std::time::Instant;
+use bytesize::ByteSize;
 
 #[global_allocator]
 static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
 
 #[test]
-#[cfg(all(feature = "parallel", features = "git-index"))]
+#[cfg(all(feature = "parallel", feature = "git-index"))]
 fn mem_usage() {
     use crates_index::Index;
     use rayon::iter::ParallelIterator;
@@ -14,15 +16,20 @@ fn mem_usage() {
 
     let before = ALLOCATOR.allocated();
     // let all_crates: Vec<_> = index.crates().collect();
+    let start = Instant::now();
     let all_crates: Vec<_> = index.crates_parallel().map(|c| c.unwrap()).collect();
     let after = ALLOCATOR.allocated();
     let used = after - before;
     assert!(all_crates.len() > 89000);
+    let elapsed = start.elapsed().as_secs_f32();
+    let per_crate = used / all_crates.len();
     eprintln!(
-        "used mem: {}B for {} crates, {}B per crate",
-        used,
+        "used mem: {}B for {} crates, {}B per crate, took {elapsed:.02}s [total-mem: {total}, peak-mem: {peak}]",
+        ByteSize(used as u64),
         all_crates.len(),
-        used / all_crates.len()
+        per_crate,
+        total = ByteSize(ALLOCATOR.total_allocated() as u64),
+        peak = ByteSize(ALLOCATOR.max_allocated() as u64),
     );
-    assert!(used / all_crates.len() < 6200);
+    assert!(per_crate < 6300, "per crate limit {per_crate}B should remain below memory limit");
 }


### PR DESCRIPTION
This PR replaces `git2` with `gix`. It does so trying to make no breaking changes to the public API.
*Please note that this is an ongoing effort, this PR will change a lot.*

##### Why now?

With the sparse index slowly becoming the new default, users of this crate will probably be less succeptible
to changes in the `git` implementation which might come with compatibility issues on windows when `ssh` is used.
Furthermore, `gix` now has a robust implementation of the negotiation protocol which allows it to work for 
crates.io proxies as well, which is important for users in China.
Making this changes has high value as it can solve a list of issues which have been open for a long time.

### Tasks 📝

* [x] repository access
* [x] creation and initial fetch (and assure parallel clones block, have a test for that)
* [x] index updates
* [x] search for `git2_` and `Git2` to find leftover references in docs to old names and fix them
* [x] make improvements to `gix` for smoother API and refer to new release here
* [x] fix conflicts with `master`
* [x] translate the new `changes` feature.
* [x] a new `gix` release with latest changes to adapt API
* [x] Make `FETCH_HEAD` handling work (the only way to see what was actually fetched) *(noticed while dog-fooding tooling built with this version)*

### Breaking Changes ❗️

* The `vendored-openssl` feature toggle was removed as there is no equivalent, additive feature in `gitoxide`. It's replaced with documentation on how to get `rustls` instead.

### Highlights 🔦

* The test-suite now runs in 5min 30s on CI, down from ~9:30 minutes.
* The `mem usage` tests seems to be a little bit faster with ~5s for `gix` and ~6s for `git2`. *(it's definitely not as fast as I would have hoped though, ODB is the bottleneck)*
* Getting the most recent 500 `changes()` takes 1.2s on `master` but only 335ms with `gix`.

### Differences to `git2` implementation ≠

* proxy-options are taken automatically and directly from `git`.
* credentials are handled as configured in `git`. This works particularly well with private registries.
* `ssh` options are handled by the `ssh` program, just like `git`. ssh-related `git` configuration is respected as well.

I am leaving it with the defaults as I think they improve compatibility and make it easier to connect to a variety of remotes.

### Potential Shortcomings ⚠️

* Windows might have benefited from a native `ssh` implementation. `gitoxide` doesn't have that yet, and uses the `ssh` program, just like git.
* ~~`gitoxide` can't read the `FETCH_HEAD`, nor does it write it. If that's an issue, this could be implemented.~~ - resolved by making an even more flexible implementation of obtaining the latest commit.

### Questions 🙋‍♂️

* ✅ **How to provide a pure-Rust HTTPS implementation while maintaining additive feature toggles?**
    - With the `https` feature, one has to make a choice. Using `curl` provides the best capabilities, but one would have to chose the `reqwest` based backend to solve the OpenSSL related issues. Ideally, this could be a choice, but that doesn't work with `gix` feature toggles as these backend features are mutually exclusive. `gix` accepts that `--all-feature` builds won't compile, but this crate might not.
    - **Answer**: document how to deal with that in the crate-root.
* **Use `fslock` instead of `gix::lock`?**
    - Doing so doesn't have the issue of needing signal handler to properly deal with signals/interrupts, but may have other failure modes.
* **How does this run on the `lib.rs` machine?** @kornelski 
    - The `mem_usage` tests also shows that both `peak` and `total` memory usage are up, but I have a feeling it counts virtual memory differently maybe. It's best to just try it and also compare performance on smaller machines.

### Related Issues 🐞

* Fixes #82
* Fixes #66
   - the need to use the `git` CLI typically stems from authentication not working correctly. `gix` doesn't have such issues and will generally authenticate remote just like `git` does, using its configuration automatically.
* Revisit #62 
   - I validated the previously parallel clones would fail due to a lock that `git2` creates, and now we use `gix` file locks to protect against concurrent access and block instead. The test-suite also makes use of this capability for better performance.
*  #44 already worked
* Fixes #37
   - `gix` uses the `ssh` program just like `git` does, so `ssh` protocol related incompatibilities should go away.
* Fixes #66 
   - A CLI fallback won't be necessary anymore as `gix` aims to behave just like `git`
* Fixes #88
   - Even though by default, OpenSSL/Curl will still be used for HTTPS, for backwards compatbility and maximum capabilities, I will add a feature toggle to allow changing the `https` backend to use a pure Rust implementation, which in turn uses `rustls`.
* Fixes https://github.com/Byron/gitoxide/issues/574 *(tracking ticket in `gitoxide`)*
