### PR TITLE
always use / as a separator for sparse urls

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -12,10 +12,13 @@ jobs:
     name: Test
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
         rust:
           - beta
           - nightly
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -26,6 +26,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -88,7 +88,7 @@ impl SparseIndex {
     #[inline]
     #[must_use]
     pub fn crate_url(&self, name: &str) -> Option<String> {
-        let rel_path = crate_name_to_relative_path(name, None)?;
+        let rel_path = crate_name_to_relative_path(name, Some('/'))?;
         Some(format!("{}{rel_path}", self.url()))
     }
 


### PR DESCRIPTION
This PR should fix #126 