### PR TITLE
NamePermutationIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ tempfile = "3.5.0"
 ureq = { version = "2.7.1", features = ["http-interop"] }
 reqwest = { version = "0.11.18", features = ["blocking", "gzip"] }
 serial_test = "2.0.0"
-itertools = "0.11.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.5.0"
 ureq = { version = "2.7.1", features = ["http-interop"] }
 reqwest = { version = "0.11.18", features = ["blocking", "gzip"] }
 serial_test = "2.0.0"
+itertools = "0.11.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,7 @@
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![forbid(unsafe_code)]
-#![deny(rust_2018_compatibility, missing_docs)]
+#![deny(unsafe_code, rust_2018_compatibility, missing_docs)]
 use std::path::{Path, PathBuf};
 
 /// Wrapper around managing the crates.io-index git repository

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,16 @@ pub struct SparseIndex {
 ///
 pub mod sparse;
 
+/// Iterator over all possible permutations of `-_` in crate names
+#[derive(Clone)]
+pub struct Names {
+    count: u32,
+    max_count: u32,
+    chars: Vec<char>,
+    separator_indexes: Vec<usize>,
+}
+mod names;
+
 mod types;
 pub use types::{Crate, Dependency, DependencyKind, Version};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,15 +155,8 @@ pub struct SparseIndex {
 ///
 pub mod sparse;
 
-/// Iterator over all possible permutations of `-_` in crate names
-#[derive(Clone)]
-pub struct Names {
-    count: u32,
-    max_count: u32,
-    chars: Vec<char>,
-    separator_indexes: Vec<usize>,
-}
 mod names;
+pub use names::Names;
 
 mod types;
 pub use types::{Crate, Dependency, DependencyKind, Version};

--- a/src/names.rs
+++ b/src/names.rs
@@ -22,7 +22,7 @@ impl Names {
                 if char == '-' || char == '_' {
                     separator_indexes[separator_count] = index;
                     separator_count += 1;
-                    '-'
+                    '_'
                 } else {
                     char
                 }
@@ -47,9 +47,9 @@ impl Iterator for Names {
             return None;
         }
 
-        for (index, string_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
-            let char = if self.count & (1 << index) == 0 { '_' } else { '-' };
-            *self.chars.get_mut(*string_index).unwrap() = char;
+        for (sep_index, char_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
+            let char = if self.count & (1 << sep_index) == 0 { '-' } else { '_' };
+            self.chars[*char_index] = char;
         }
 
         self.count += 1;

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,0 +1,82 @@
+use crate::Names;
+
+impl Names {
+    /// creates a new Iterator based on the given name
+    pub fn new(name: &str) -> Names {
+        let mut separator_indexes = vec![];
+
+        let chars: Vec<char> = name
+            .chars()
+            .enumerate()
+            .map(|(index, char)| {
+                if char == '-' || char == '_' {
+                    separator_indexes.push(index);
+                    return '-';
+                }
+
+                char
+            })
+            .collect();
+
+        Names {
+            count: 0,
+            max_count: 2u32.pow(separator_indexes.len() as u32),
+            chars,
+            separator_indexes,
+        }
+    }
+}
+
+impl Iterator for Names {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count == self.max_count {
+            return None;
+        }
+
+        for (index, string_index) in self.separator_indexes.iter().enumerate() {
+            let char = if self.count & (1 << index) == 0 { '_' } else { '-' };
+
+            *self.chars.get_mut(*string_index).unwrap() = char;
+        }
+
+        self.count += 1;
+
+        Some(self.chars.iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Names;
+    use itertools::Itertools;
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(Names::new("").dedup().count(), 1);
+    }
+
+    #[test]
+    fn string_with_out_separators() {
+        assert_eq!(Names::new("serde").dedup().count(), 1);
+    }
+
+    #[test]
+    fn string_with_separators() {
+        assert_eq!(Names::new("serde-test").dedup().count(), 2);
+        assert_eq!(Names::new("serde-test_2").dedup().count(), 4);
+        assert_eq!(Names::new("serde_test_2").dedup().count(), 4);
+        assert_eq!(Names::new("serde_test_2-test").dedup().count(), 8);
+    }
+
+    #[test]
+    fn correct_strings() {
+        let names = Names::new("serde-test-2");
+
+        assert!(names.clone().contains(&"serde-test-2".to_string()));
+        assert!(names.clone().contains(&"serde-test_2".to_string()));
+        assert!(names.clone().contains(&"serde_test_2".to_string()));
+        assert!(names.clone().contains(&"serde_test-2".to_string()));
+    }
+}

--- a/src/names.rs
+++ b/src/names.rs
@@ -3,7 +3,7 @@
 pub struct Names {
     count: u16,
     max_count: u16,
-    chars: Vec<char>,
+    current: String,
     separator_indexes: [usize; 17],
     separator_count: usize,
 }
@@ -13,9 +13,9 @@ impl Names {
     /// or `None` if there are more than 15 `-` or `_` characters.
     pub fn new(name: &str) -> Option<Names> {
         let mut separator_indexes = [0; 17];
-
         let mut separator_count = 0;
-        let chars: Vec<char> = name
+
+        let current: String = name
             .chars()
             .enumerate()
             .map(|(index, char)| {
@@ -32,7 +32,7 @@ impl Names {
         Some(Names {
             count: 0,
             max_count: 2u16.checked_pow(separator_count.try_into().ok()?)?,
-            chars,
+            current,
             separator_indexes,
             separator_count,
         })
@@ -43,16 +43,20 @@ impl Iterator for Names {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.count == self.max_count {
+        let count = &mut self.count;
+        if *count >= self.max_count {
             return None;
         }
 
         for (sep_index, char_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
-            let char = if self.count & (1 << sep_index) == 0 { '-' } else { '_' };
-            self.chars[*char_index] = char;
+            let char = if *count & (1 << sep_index) == 0 { b'-' } else { b'_' };
+            // SAFETY: We validated that `char_index` is a valid UTF-8 codepoint
+            #[allow(unsafe_code)]
+            unsafe {
+                self.current.as_bytes_mut()[*char_index] = char;
+            }
         }
-
-        self.count += 1;
-        Some(self.chars.iter().collect())
+        *count += 1;
+        Some(self.current.clone())
     }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,7 +1,8 @@
 /// Iterator over all possible permutations of `-_` in crate names
 #[derive(Clone)]
 pub struct Names {
-    count: u16,
+    count: Option<u16>,
+    initial: String,
     max_count: u16,
     current: String,
     separator_indexes: [usize; 17],
@@ -11,10 +12,11 @@ pub struct Names {
 impl Names {
     /// Creates a new iterator over all permutations of `-` and `_` of the given `name`,
     /// or `None` if there are more than 15 `-` or `_` characters.
-    pub fn new(name: &str) -> Option<Names> {
+    pub fn new(name: impl Into<String>) -> Option<Names> {
         let mut separator_indexes = [0; 17];
         let mut separator_count = 0;
 
+        let name = name.into();
         let current: String = name
             .chars()
             .enumerate()
@@ -30,7 +32,8 @@ impl Names {
             .collect();
 
         Some(Names {
-            count: 0,
+            count: None,
+            initial: name,
             max_count: 2u16.checked_pow(separator_count.try_into().ok()?)?,
             current,
             separator_indexes,
@@ -43,20 +46,33 @@ impl Iterator for Names {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let count = &mut self.count;
-        if *count >= self.max_count {
-            return None;
-        }
+        match self.count.as_mut() {
+            None => {
+                self.count = Some(0);
+                self.initial.clone().into()
+            }
+            Some(count) => {
+                for _round in 0..2 {
+                    if *count == self.max_count {
+                        return None;
+                    }
 
-        for (sep_index, char_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
-            let char = if *count & (1 << sep_index) == 0 { b'-' } else { b'_' };
-            // SAFETY: We validated that `char_index` is a valid UTF-8 codepoint
-            #[allow(unsafe_code)]
-            unsafe {
-                self.current.as_bytes_mut()[*char_index] = char;
+                    for (sep_index, char_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
+                        let char = if *count & (1 << sep_index) == 0 { b'-' } else { b'_' };
+                        // SAFETY: We validated that `char_index` is a valid UTF-8 codepoint
+                        #[allow(unsafe_code)]
+                        unsafe {
+                            self.current.as_bytes_mut()[*char_index] = char;
+                        }
+                    }
+
+                    *count += 1;
+                    if self.current != self.initial {
+                        break;
+                    }
+                }
+                Some(self.current.clone())
             }
         }
-        *count += 1;
-        Some(self.current.clone())
     }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -4,33 +4,37 @@ pub struct Names {
     count: u16,
     max_count: u16,
     chars: Vec<char>,
-    separator_indexes: Vec<usize>,
+    separator_indexes: [usize; 17],
+    separator_count: usize,
 }
 
 impl Names {
     /// Creates a new iterator over all permutations of `-` and `_` of the given `name`,
     /// or `None` if there are more than 15 `-` or `_` characters.
     pub fn new(name: &str) -> Option<Names> {
-        let mut separator_indexes = vec![];
+        let mut separator_indexes = [0; 17];
 
+        let mut separator_count = 0;
         let chars: Vec<char> = name
             .chars()
             .enumerate()
             .map(|(index, char)| {
                 if char == '-' || char == '_' {
-                    separator_indexes.push(index);
-                    return '-';
+                    separator_indexes[separator_count] = index;
+                    separator_count += 1;
+                    '-'
+                } else {
+                    char
                 }
-
-                char
             })
             .collect();
 
         Some(Names {
             count: 0,
-            max_count: 2u16.checked_pow(separator_indexes.len().try_into().ok()?)?,
+            max_count: 2u16.checked_pow(separator_count.try_into().ok()?)?,
             chars,
             separator_indexes,
+            separator_count,
         })
     }
 }
@@ -43,7 +47,7 @@ impl Iterator for Names {
             return None;
         }
 
-        for (index, string_index) in self.separator_indexes.iter().enumerate() {
+        for (index, string_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
             let char = if self.count & (1 << index) == 0 { '_' } else { '-' };
             *self.chars.get_mut(*string_index).unwrap() = char;
         }

--- a/src/names.rs
+++ b/src/names.rs
@@ -49,7 +49,6 @@ impl Iterator for Names {
         }
 
         self.count += 1;
-
         Some(self.chars.iter().collect())
     }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,15 +1,16 @@
 /// Iterator over all possible permutations of `-_` in crate names
 #[derive(Clone)]
 pub struct Names {
-    count: u32,
-    max_count: u32,
+    count: u16,
+    max_count: u16,
     chars: Vec<char>,
     separator_indexes: Vec<usize>,
 }
 
 impl Names {
-    /// creates a new Iterator based on the given name
-    pub fn new(name: &str) -> Names {
+    /// Creates a new iterator over all permutations of `-` and `_` of the given `name`,
+    /// or `None` if there are more than 15 `-` or `_` characters.
+    pub fn new(name: &str) -> Option<Names> {
         let mut separator_indexes = vec![];
 
         let chars: Vec<char> = name
@@ -25,12 +26,12 @@ impl Names {
             })
             .collect();
 
-        Names {
+        Some(Names {
             count: 0,
-            max_count: 2u32.pow(separator_indexes.len() as u32),
+            max_count: 2u16.checked_pow(separator_indexes.len().try_into().ok()?)?,
             chars,
             separator_indexes,
-        }
+        })
     }
 }
 
@@ -44,7 +45,6 @@ impl Iterator for Names {
 
         for (index, string_index) in self.separator_indexes.iter().enumerate() {
             let char = if self.count & (1 << index) == 0 { '_' } else { '-' };
-
             *self.chars.get_mut(*string_index).unwrap() = char;
         }
 

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,4 +1,11 @@
-use crate::Names;
+/// Iterator over all possible permutations of `-_` in crate names
+#[derive(Clone)]
+pub struct Names {
+    count: u32,
+    max_count: u32,
+    chars: Vec<char>,
+    separator_indexes: Vec<usize>,
+}
 
 impl Names {
     /// creates a new Iterator based on the given name
@@ -44,39 +51,5 @@ impl Iterator for Names {
         self.count += 1;
 
         Some(self.chars.iter().collect())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::Names;
-    use itertools::Itertools;
-
-    #[test]
-    fn empty_string() {
-        assert_eq!(Names::new("").dedup().count(), 1);
-    }
-
-    #[test]
-    fn string_with_out_separators() {
-        assert_eq!(Names::new("serde").dedup().count(), 1);
-    }
-
-    #[test]
-    fn string_with_separators() {
-        assert_eq!(Names::new("serde-test").dedup().count(), 2);
-        assert_eq!(Names::new("serde-test_2").dedup().count(), 4);
-        assert_eq!(Names::new("serde_test_2").dedup().count(), 4);
-        assert_eq!(Names::new("serde_test_2-test").dedup().count(), 8);
-    }
-
-    #[test]
-    fn correct_strings() {
-        let names = Names::new("serde-test-2");
-
-        assert!(names.clone().contains(&"serde-test-2".to_string()));
-        assert!(names.clone().contains(&"serde-test_2".to_string()));
-        assert!(names.clone().contains(&"serde_test_2".to_string()));
-        assert!(names.clone().contains(&"serde_test-2".to_string()));
     }
 }

--- a/tests/crates_index.rs
+++ b/tests/crates_index.rs
@@ -1,4 +1,5 @@
 mod git;
+mod names;
 mod sparse_index;
 mod error {
     #[test]

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -2,20 +2,34 @@ use crates_index::Names;
 
 #[test]
 fn empty_string() {
-    assert_eq!(Names::new("").count(), 1);
+    assert_eq!(Names::new("").unwrap().count(), 1);
 }
 
 #[test]
 fn name_without_separators_yields_name() {
-    assert_eq!(Names::new("serde").count(), 1);
+    assert_eq!(Names::new("serde").unwrap().count(), 1);
 }
 
 #[test]
 fn permutation_count() {
-    assert_eq!(Names::new("a-b").count(), 2);
-    assert_eq!(Names::new("a-b_c").count(), 4);
-    assert_eq!(Names::new("a_b_c").count(), 4);
-    assert_eq!(Names::new("a_b_c-d").count(), 8);
+    assert_eq!(Names::new("a-b").unwrap().count(), 2);
+    assert_eq!(Names::new("a-b_c").unwrap().count(), 4);
+    assert_eq!(Names::new("a_b_c").unwrap().count(), 4);
+    assert_eq!(Names::new("a_b_c-d").unwrap().count(), 8);
+}
+
+#[test]
+fn max_permutation_count_causes_error() {
+    assert_eq!(
+        Names::new("a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p")
+            .expect("15 separators are fine")
+            .count(),
+        32768
+    );
+    assert!(
+        Names::new("a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r").is_none(),
+        "17 are not fine anymore"
+    );
 }
 
 #[test]
@@ -25,7 +39,7 @@ fn permutations() {
         ("a-b", &["a_b", "a-b"] as &[_]),
         ("a-b-c", &["a_b_c", "a-b_c", "a_b-c", "a-b-c"]),
     ] {
-        let names: Vec<String> = Names::new(name).collect();
+        let names: Vec<String> = Names::new(name).unwrap().collect();
         assert_eq!(&names, expected);
     }
 }

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -35,8 +35,8 @@ fn max_permutation_count_causes_error() {
 #[test]
 fn permutations() {
     for (name, expected) in [
-        ("a_b", &["a-b", "a_b"] as &[_]),
-        ("parking_lot", &["parking-lot", "parking_lot"]), // Ideally, the input name is always the first one returned.
+        ("parking_lot", &["parking-lot", "parking_lot"] as &[_]), // the input name is always the first one returned.
+        ("a_b", &["a-b", "a_b"]),
         ("a-b", &["a-b", "a_b"]),
         ("a-b-c", &["a-b-c", "a_b-c", "a-b_c", "a_b_c"]),
         (

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -1,30 +1,31 @@
 use crates_index::Names;
-use itertools::Itertools;
 
 #[test]
 fn empty_string() {
-    assert_eq!(Names::new("").dedup().count(), 1);
+    assert_eq!(Names::new("").count(), 1);
 }
 
 #[test]
-fn string_with_out_separators() {
-    assert_eq!(Names::new("serde").dedup().count(), 1);
+fn name_without_separators_yields_name() {
+    assert_eq!(Names::new("serde").count(), 1);
 }
 
 #[test]
-fn string_with_separators() {
-    assert_eq!(Names::new("serde-test").dedup().count(), 2);
-    assert_eq!(Names::new("serde-test_2").dedup().count(), 4);
-    assert_eq!(Names::new("serde_test_2").dedup().count(), 4);
-    assert_eq!(Names::new("serde_test_2-test").dedup().count(), 8);
+fn permutation_count() {
+    assert_eq!(Names::new("a-b").count(), 2);
+    assert_eq!(Names::new("a-b_c").count(), 4);
+    assert_eq!(Names::new("a_b_c").count(), 4);
+    assert_eq!(Names::new("a_b_c-d").count(), 8);
 }
 
 #[test]
-fn correct_strings() {
-    let names = Names::new("serde-test-2");
-
-    assert!(names.clone().contains(&"serde-test-2".to_string()));
-    assert!(names.clone().contains(&"serde-test_2".to_string()));
-    assert!(names.clone().contains(&"serde_test_2".to_string()));
-    assert!(names.clone().contains(&"serde_test-2".to_string()));
+fn permutations() {
+    for (name, expected) in [
+        ("a_b", &["a_b", "a-b"] as &[_]),
+        ("a-b", &["a_b", "a-b"] as &[_]),
+        ("a-b-c", &["a_b_c", "a-b_c", "a_b-c", "a-b-c"]),
+    ] {
+        let names: Vec<String> = Names::new(name).collect();
+        assert_eq!(&names, expected);
+    }
 }

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -1,0 +1,30 @@
+use crates_index::Names;
+use itertools::Itertools;
+
+#[test]
+fn empty_string() {
+    assert_eq!(Names::new("").dedup().count(), 1);
+}
+
+#[test]
+fn string_with_out_separators() {
+    assert_eq!(Names::new("serde").dedup().count(), 1);
+}
+
+#[test]
+fn string_with_separators() {
+    assert_eq!(Names::new("serde-test").dedup().count(), 2);
+    assert_eq!(Names::new("serde-test_2").dedup().count(), 4);
+    assert_eq!(Names::new("serde_test_2").dedup().count(), 4);
+    assert_eq!(Names::new("serde_test_2-test").dedup().count(), 8);
+}
+
+#[test]
+fn correct_strings() {
+    let names = Names::new("serde-test-2");
+
+    assert!(names.clone().contains(&"serde-test-2".to_string()));
+    assert!(names.clone().contains(&"serde-test_2".to_string()));
+    assert!(names.clone().contains(&"serde_test_2".to_string()));
+    assert!(names.clone().contains(&"serde_test-2".to_string()));
+}

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -35,9 +35,16 @@ fn max_permutation_count_causes_error() {
 #[test]
 fn permutations() {
     for (name, expected) in [
-        ("a_b", &["a_b", "a-b"] as &[_]),
-        ("a-b", &["a_b", "a-b"] as &[_]),
-        ("a-b-c", &["a_b_c", "a-b_c", "a_b-c", "a-b-c"]),
+        ("a_b", &["a-b", "a_b"] as &[_]),
+        ("parking_lot", &["parking-lot", "parking_lot"]), // Ideally, the input name is always the first one returned.
+        ("a-b", &["a-b", "a_b"]),
+        ("a-b-c", &["a-b-c", "a_b-c", "a-b_c", "a_b_c"]),
+        (
+            "a-b-c-d",
+            &[
+                "a-b-c-d", "a_b-c-d", "a-b_c-d", "a_b_c-d", "a-b-c_d", "a_b-c_d", "a-b_c_d", "a_b_c_d",
+            ],
+        ),
     ] {
         let names: Vec<String> = Names::new(name).unwrap().collect();
         assert_eq!(&names, expected);

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -35,14 +35,20 @@ fn max_permutation_count_causes_error() {
 #[test]
 fn permutations() {
     for (name, expected) in [
-        ("parking_lot", &["parking-lot", "parking_lot"] as &[_]), // the input name is always the first one returned.
-        ("a_b", &["a-b", "a_b"]),
+        ("parking_lot", &["parking_lot", "parking-lot"] as &[_]), // the input name is always the first one returned.
+        ("a_b", &["a_b", "a-b"]),
         ("a-b", &["a-b", "a_b"]),
         ("a-b-c", &["a-b-c", "a_b-c", "a-b_c", "a_b_c"]),
         (
             "a-b-c-d",
             &[
                 "a-b-c-d", "a_b-c-d", "a-b_c-d", "a_b_c-d", "a-b-c_d", "a_b-c_d", "a-b_c_d", "a_b_c_d",
+            ],
+        ),
+        (
+            "a_b_c_d",
+            &[
+                "a_b_c_d", "a-b-c-d", "a_b-c-d", "a-b_c-d", "a_b_c-d", "a-b-c_d", "a_b-c_d", "a-b_c_d",
             ],
         ),
     ] {


### PR DESCRIPTION
This PR adds the in #75 suggested `NamesIter`

open Questions:

- how to handle too many `-_`?
  In case of more than 32 separators, the programs would just crash with an `attempt to multiply with overflow`.
  I don't think handling it as a `Result<>` would be reasonable as this case is not realistic and using `Result<>` would make the API worse (at least in my opinion)
- should the iter return `&str`?

note:
I am not really happy with the code but every attempt of improving it just made it worse...