### PR TITLE
minor Names optimizations

### DIFF
--- a/src/names.rs
+++ b/src/names.rs
@@ -78,4 +78,11 @@ impl Iterator for Names {
             }
         }
     }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.max_count as usize
+    }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -60,8 +60,11 @@ impl Iterator for Names {
                         return None;
                     }
 
+                    //map the count so the first value is the last one (all "-"), the second one is the first one (all "_")...
+                    let used_count = *count as isize - 1 + self.max_count as isize;
+
                     for (sep_index, char_index) in self.separator_indexes[..self.separator_count].iter().enumerate() {
-                        let char = if *count & (1 << sep_index) == 0 { b'-' } else { b'_' };
+                        let char = if used_count & (1 << sep_index) == 0 { b'_' } else { b'-' };
                         // SAFETY: We validated that `char_index` is a valid UTF-8 codepoint
                         #[allow(unsafe_code)]
                         unsafe {

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -46,19 +46,25 @@ fn max_permutation_count_causes_error() {
 fn permutations() {
     for (name, expected) in [
         ("parking_lot", &["parking_lot", "parking-lot"] as &[_]), // the input name is always the first one returned.
+        (
+            "a-b_c-d", // input name -> all-hyphens -> all_underscores -> rest
+            &[
+                "a-b_c-d", "a-b-c-d", "a_b_c_d", "a-b_c_d", "a_b-c_d", "a-b-c_d", "a_b_c-d", "a_b-c-d",
+            ],
+        ),
         ("a_b", &["a_b", "a-b"]),
         ("a-b", &["a-b", "a_b"]),
-        ("a-b-c", &["a-b-c", "a_b-c", "a-b_c", "a_b_c"]),
+        ("a-b-c", &["a-b-c", "a_b_c", "a-b_c", "a_b-c"]),
         (
             "a-b-c-d",
             &[
-                "a-b-c-d", "a_b-c-d", "a-b_c-d", "a_b_c-d", "a-b-c_d", "a_b-c_d", "a-b_c_d", "a_b_c_d",
+                "a-b-c-d", "a_b_c_d", "a-b_c_d", "a_b-c_d", "a-b-c_d", "a_b_c-d", "a-b_c-d", "a_b-c-d",
             ],
         ),
         (
             "a_b_c_d",
             &[
-                "a_b_c_d", "a-b-c-d", "a_b-c-d", "a-b_c-d", "a_b_c-d", "a-b-c_d", "a_b-c_d", "a-b_c_d",
+                "a_b_c_d", "a-b-c-d", "a-b_c_d", "a_b-c_d", "a-b-c_d", "a_b_c-d", "a-b_c-d", "a_b-c-d",
             ],
         ),
     ] {

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -38,7 +38,7 @@ fn max_permutation_count_causes_error() {
     );
     assert!(
         Names::new("a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r").is_none(),
-        "17 are not fine anymore"
+        "16 are not fine anymore"
     );
 }
 

--- a/tests/names/mod.rs
+++ b/tests/names/mod.rs
@@ -1,13 +1,17 @@
 use crates_index::Names;
 
+fn data_count(names: Names) -> usize {
+    names.collect::<Vec<String>>().len()
+}
+
 #[test]
 fn empty_string() {
-    assert_eq!(Names::new("").unwrap().count(), 1);
+    assert_eq!(data_count(Names::new("").unwrap()), 1);
 }
 
 #[test]
 fn name_without_separators_yields_name() {
-    assert_eq!(Names::new("serde").unwrap().count(), 1);
+    assert_eq!(data_count(Names::new("serde").unwrap()), 1);
 }
 
 #[test]
@@ -19,11 +23,17 @@ fn permutation_count() {
 }
 
 #[test]
+fn permutation_data_count() {
+    assert_eq!(data_count(Names::new("a-b").unwrap()), 2);
+    assert_eq!(data_count(Names::new("a-b_c").unwrap()), 4);
+    assert_eq!(data_count(Names::new("a_b_c").unwrap()), 4);
+    assert_eq!(data_count(Names::new("a_b_c-d").unwrap()), 8);
+}
+
+#[test]
 fn max_permutation_count_causes_error() {
     assert_eq!(
-        Names::new("a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p")
-            .expect("15 separators are fine")
-            .count(),
+        data_count(Names::new("a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p").expect("15 separators are fine")),
         32768
     );
     assert!(


### PR DESCRIPTION
This PR adds some small improvements to `Names`

- overwriting `count()` to improve performance
  I added a 'custom' `count()` for tests as they otherwise would not really test the functionality 
- it now returns `input`, `all-hyphens`, `all_underscores`, `…all remaining permutations…`