### PR TITLE
example "update_and_get_latest" requires "git-https"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["sparse"]
 
 [[example]]
 name = "update_and_get_latest"
-required-features = ["git"]
+required-features = ["git-https"]
 
 [dependencies]
 gix = { version = "0.50.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }


### PR DESCRIPTION
when running the `update_and_get_latest` example you get this error when only using the `git` feature 
`Error: Git(RemoteConnect(Connect(CompiledWithoutHttp(Https))))`
