### PR TITLE
update sparse_http_ureq to use ureq 2.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ bytesize = "1.2.0"
 cap = { version = "0.1.2", features = ["stats"] }
 is_ci = "1.1.1"
 tempfile = "3.5.0"
-ureq = { version = "2.7.1", features = ["http-interop"] }
+ureq = { version = "2.8.0", features = ["http-interop"] }
 reqwest = { version = "0.11.18", features = ["blocking", "gzip"] }
 serial_test = "2.0.0"
 parking_lot = "0.12.1"

--- a/examples/sparse_http_reqwest.rs
+++ b/examples/sparse_http_reqwest.rs
@@ -5,7 +5,7 @@ use crates_index::SparseIndex;
 /// dont forget to enable the **["blocking", "gzip"]** feature of **reqwest**
 ///
 /// command to run:<br>
-/// cargo run --example sparse_http_reqwest -F sparse-http
+/// cargo run --example sparse_http_reqwest -F sparse
 ///
 
 const CRATE_TO_FETCH: &str = "names";

--- a/examples/sparse_http_ureq.rs
+++ b/examples/sparse_http_ureq.rs
@@ -6,7 +6,7 @@ use std::io;
 /// dont forget to enable the **http-interop** feature of **ureq**
 ///
 /// command to run:<br>
-/// cargo run --example sparse_http_ureq -F sparse-http
+/// cargo run --example sparse_http_ureq -F sparse
 ///
 
 const CRATE_TO_FETCH: &str = "inferno";
@@ -33,14 +33,10 @@ fn print_crate(index: &mut SparseIndex) {
 fn update(index: &mut SparseIndex) {
     let request: ureq::Request = index.make_cache_request(CRATE_TO_FETCH).unwrap().into();
 
-    let response: http::Response<String> = request
+    let response = request
         .call()
         .map_err(|_e| io::Error::new(io::ErrorKind::InvalidInput, "connection error"))
-        .unwrap()
-        .into();
+        .unwrap();
 
-    let (parts, body) = response.into_parts();
-    let response = http::Response::from_parts(parts, body.into_bytes());
-
-    index.parse_cache_response(CRATE_TO_FETCH, response, true).unwrap();
+    index.parse_cache_response(CRATE_TO_FETCH, response.into(), true).unwrap();
 }


### PR DESCRIPTION
This PR updates the `sparse_http_ureq` example to use ureq 2.8.0 which enables a simpler type conversion.