### PR TITLE
update `http` and add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ required-features = ["sparse"]
 name = "update_and_get_latest"
 required-features = ["git-https"]
 
+[[example]]
+name = "update_and_get_most_recent_version"
+required-features = ["git-https"]
+
 [dependencies]
 gix = { version = "0.55.2", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/examples/update_and_get_latest.rs
+++ b/examples/update_and_get_latest.rs
@@ -1,11 +1,11 @@
 //! Updates the local git registry and extracts the latest most recent changes.
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut index = crates_index::GitIndex::new_cargo_default()?;
-    println!("Updating index…");
+    eprintln!("Updating index…");
     index.update()?;
 
     let limit = 10;
-    println!("The most recent {limit} changes:\n");
+    eprintln!("The most recent {limit} changes:\n");
     for change in index.changes()?.take(limit) {
         let change = change?;
         println!(

--- a/examples/update_and_get_most_recent_version.rs
+++ b/examples/update_and_get_most_recent_version.rs
@@ -1,0 +1,21 @@
+//! Updates the local git registry and extracts the latest most recent changes.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let crate_name = std::env::args()
+        .nth(1)
+        .ok_or("The first argument must be the name of the crate to get the most recent version of")?;
+    let mut index = crates_index::GitIndex::new_cargo_default()?;
+    eprintln!("Updating index…");
+    index.update()?;
+
+    let krate = index
+        .crate_(&crate_name)
+        .ok_or_else(|| format!("Crate named '{crate_name}' does not exist in git index"))?;
+    println!("most recent   : {}", krate.most_recent_version().version());
+    println!(
+        "highest normal: {:?}",
+        krate.highest_normal_version().map(|v| v.version())
+    );
+    println!("highest       : {}", krate.highest_version().version());
+    println!("earliest      : {}", krate.earliest_version().version());
+    Ok(())
+}

--- a/src/git/impl_.rs
+++ b/src/git/impl_.rs
@@ -520,6 +520,7 @@ impl Iterator for CratesTreesToBlobs {
 
 enum MaybeOwned<'a, T> {
     Owned(T),
+    #[cfg_attr(not(feature = "parallel"), allow(dead_code))]
     Borrowed(&'a mut T),
 }
 


### PR DESCRIPTION
- chore: upgrade `http` to v1.0
- add new example to list the most recent version of a crate using the git index


Also validated that git index updates work as they should, and it indeed seems to be the case. 