### PR TITLE
fix: assure Git index updates to refs are actually written.

### DIFF
--- a/src/git/impl_.rs
+++ b/src/git/impl_.rs
@@ -239,7 +239,7 @@ impl GitIndex {
             .unwrap_or_else(|| self.repo.remote_at(self.url.as_str()).expect("own URL is always valid"));
         fetch_remote(
             &mut remote,
-            &["HEAD:refs/remotes/origin/HEAD", "master:refs/remotes/origin/master"],
+            &["+HEAD:refs/remotes/origin/HEAD", "+master:refs/remotes/origin/master"],
         )?;
 
         let head_commit = Self::find_repo_head(&self.repo, &self.path)?;


### PR DESCRIPTION
The remote git repository may alter its references in such a way that
local fast-forwards aren't possible anymore.

This happens regularly as the history will be squashed on the remote.

Now we forcefully store the updated references, which resolves
the issue that calling `update()` didn't seem to do anything despite
being busy (i.e. downloading a possibly huge pack, and resolving it).
