### PR TITLE
chore: update to gix v0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ name = "update_and_get_most_recent_version"
 required-features = ["git-https"]
 
 [dependencies]
-gix = { version = "0.58.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
+gix = { version = "0.59.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "0.2", optional = true }


### PR DESCRIPTION
Right now `cargo check -F git` is broken.

Error:

```
error[E0599]: the method `context` exists for fn item `fn(&mut &[u8]) -> Result<SignatureRef<'_>, ErrMode<_>> {decode::<'_, _>}`, but its trait bounds were not satisfied
   --> /Users/marcoieni/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-ref-0.41.0/src/store/file/log/line.rs:142:46
    |
142 |                 gix_actor::signature::decode.context(StrContext::Expected("<name> <<email>> <timestamp>".into())),
    |                                              ^^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `<for<'a> fn(&'a mut &[u8]) -> Result<SignatureRef<'_>, winnow::error::ErrMode<_>> {gix_actor::signature::decode::<'_, _>} as FnOnce<(&mut _,)>>::Output = Result<_, ErrMode<_>>`
            which is required by `for<'a> fn(&'a mut &[u8]) -> Result<SignatureRef<'_>, winnow::error::ErrMode<_>> {gix_actor::signature::decode::<'_, _>}: winnow::Parser<_, _, _>`
            `<&for<'a> fn(&'a mut &[u8]) -> Result<SignatureRef<'_>, winnow::error::ErrMode<_>> {gix_actor::signature::decode::<'_, _>} as FnOnce<(&mut _,)>>::Output = Result<_, ErrMode<_>>`
            which is required by `&for<'a> fn(&'a mut &[u8]) -> Result<SignatureRef<'_>, winnow::error::ErrMode<_>> {gix_actor::signature::decode::<'_, _>}: winnow::Parser<_, _, _>`
            `<&mut for<'a> fn(&'a mut &[u8]) -> Result<SignatureRef<'_>, winnow::error::ErrMode<_>> {gix_actor::signature::decode::<'_, _>} as FnOnce<(&mut _,)>>::Output = Result<_, ErrMode<_>>`
            which is required by `&mut for<'a> fn(&'a mut &[u8]) -> Result<SignatureRef<'_>, winnow::error::ErrMode<_>> {gix_actor::signature::decode::<'_, _>}: winnow::Parser<_, _, _>`
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
76  +     use winnow::parser::Parser;
    |
```

This PR seems to fix the issue.

If you accept this PR and merge it, can you release a new version, too, please?
My crate doesn't compile for this reason.