### PR TITLE
gix upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crates-index"
 description = "Library for retrieving and interacting with the crates.io index"
-version = "2.7.0"
+version = "2.8.0"
 homepage = "https://crates.io/crates/crates-index"
 authors = ["Corey Farwell <coreyf@rwell.org>", "Kornel <kornel@geekhood.net>"]
 keywords = ["packaging", "index", "dependencies", "crate", "meta"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ name = "update_and_get_most_recent_version"
 required-features = ["git-https"]
 
 [dependencies]
-gix = { version = "0.58.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
+gix = { version = "0.62.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "0.2", optional = true }


### PR DESCRIPTION
- **chore: upgrade gix to v0.62**
- **bump minor version to indicate 'gix' upgrade.**
