### PR TITLE
git: Bail out if the url is `sparse`

### DIFF
--- a/examples/list_recent_versions.rs
+++ b/examples/list_recent_versions.rs
@@ -69,9 +69,7 @@ fn fetch_crate(name: &str, sparse_index: &SparseIndex) -> Result<Option<Crate>, 
 }
 
 fn names(name: &str) -> Result<impl Iterator<Item = String>, Box<dyn Error>> {
-    Ok(Names::new(name)
-        .ok_or_else(|| "Too many hyphens in crate name")?
-        .take(3))
+    Ok(Names::new(name).ok_or("Too many hyphens in crate name")?.take(3))
 }
 
 /// Create a request to the sparse `index` and parse the response with the side-effect of yielding

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,11 +7,14 @@ pub use toml::de::Error as TomlDeError;
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error("\"gix\" crate failed. If problems persist, consider deleting `~/.cargo/registry/index/github.com-1ecc6299db9ec823/`")]
+    // ~/.cargo/registry/index/github.com-1ecc6299db9ec823/
+    #[error("\"gix\" crate failed. If problems persist, consider deleting `TODO`")]
     #[cfg(feature = "git")]
-    Git(#[from] GixError),
+    Git(#[from] GixError), // String
     #[error("{0}")]
     Url(String),
+    #[error("GitIndex cannot take sparse URL `{0}`, use SparseIndex")]
+    UrlIsSparse(String),
     #[error("Could not obtain the most recent head commit in repo at {}. Tried {}, had {} available", repo_path.display(), refs_tried.join(", "), refs_available.join(", "))]
     MissingHead {
         /// The references we tried to get commits for.

--- a/src/git/impl_.rs
+++ b/src/git/impl_.rs
@@ -24,7 +24,7 @@ impl Change {
     #[inline]
     #[must_use]
     pub fn crate_name(&self) -> &str {
-        &*self.crate_name
+        &self.crate_name
     }
 
     /// Timestamp in the crates.io index repository, which may be publication or modification date
@@ -155,6 +155,10 @@ impl GitIndex {
     }
 
     fn from_path_and_url(path: PathBuf, url: String, mode: Mode) -> Result<Option<Self>, Error> {
+        if url.starts_with("sparse+http") {
+            return Err(Error::UrlIsSparse(url.to_owned()));
+        }
+
         let open_with_complete_config = gix::open::Options::default().permissions(gix::open::Permissions {
             config: gix::open::permissions::Config {
                 // Be sure to get all configuration, some of which is only known by the git binary.


### PR DESCRIPTION
I ended up in the accidental case where my URL is sparse, and believe this could also happen if someone uses `replace-with` in their `.cargo/ config.toml`.  When `GitIndex` is created, this ends up with a rather useless error:

    Refusing to initialize the non-empty directory as '/home/me/.cargo/registry/index/my-custom-registry'

Because it is probably not finding a `git` repository at that place, without realizing that it's a sparse index cache.

To solve the `replace-with` case above, or make this crate more generally usable, shouldn't there be (if there isn't already) a high-level wrapper that automatically delegates to `SparseIndex` if the URL starts with `sparse+`, and hide the `GitIndex`/`SparseIndex` "internals"?
