### PR TITLE
Upgrade to http 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ required-features = ["git-https"]
 gix = { version = "0.62.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
-http = { version = "0.2", optional = true }
+http = { version = "1", optional = true }
 memchr = "2.5.0"
 rayon = { version = "1.7.0", optional = true }
 rustc-hash = "1.1.0"
@@ -56,8 +56,8 @@ bytesize = "1.2.0"
 cap = { version = "0.1.2", features = ["stats"] }
 is_ci = "1.1.1"
 tempfile = "3.5.0"
-ureq = { version = "2.8.0", features = ["http-interop"] }
-reqwest = { version = "0.11.18", features = ["blocking", "gzip"] }
+ureq = { version = "2.8.0", features = ["http-crate"] }
+reqwest = { version = "0.12", features = ["blocking", "gzip"] }
 serial_test = "2.0.0"
 parking_lot = "0.12.1"
 

--- a/examples/list_recent_versions.rs
+++ b/examples/list_recent_versions.rs
@@ -77,7 +77,7 @@ fn names(name: &str) -> Result<impl Iterator<Item = String>, Box<dyn Error>> {
 /// Create a request to the sparse `index` and parse the response with the side-effect of yielding
 /// the desired crate and updating the local cache.
 fn update_cache(name: &str, index: &SparseIndex) -> Result<Option<Crate>, Box<dyn Error>> {
-    let request: ureq::Request = index.make_cache_request(name)?.into();
+    let request: ureq::Request = index.make_cache_request(name)?.try_into()?;
 
     let response: http::Response<String> = match request.call() {
         Ok(response) => response.into(),

--- a/examples/sparse_http_ureq.rs
+++ b/examples/sparse_http_ureq.rs
@@ -31,7 +31,7 @@ fn print_crate(index: &mut SparseIndex) {
 }
 
 fn update(index: &mut SparseIndex) {
-    let request: ureq::Request = index.make_cache_request(CRATE_TO_FETCH).unwrap().into();
+    let request: ureq::Request = index.make_cache_request(CRATE_TO_FETCH).unwrap().try_into().unwrap();
 
     let response = request
         .call()


### PR DESCRIPTION
This PR upgrades the `http` dependency to version 1. This allows [directly converting from `reqwest::Response` to `http::Response`](https://docs.rs/reqwest/latest/reqwest/struct.Response.html#impl-From%3CResponse%3E-for-Response%3CBody%3E) rather than manually building the response as [shown in the example](https://github.com/frewsxcv/rust-crates-index/blob/4be1703d13817d76896f98084ee1a06a2533125a/examples/sparse_http_reqwest.rs#L44-L52). Note that this conversion is only implemented for regular (async) responses, so the example (which uses `reqwest::blocking`) remains unchanged.