### PR TITLE
Upgrade `gix` to version 0.63.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,10 @@ name = "update_and_get_most_recent_version"
 required-features = ["git-https"]
 
 [dependencies]
-gix = { version = "0.62.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"], optional = true }
+gix = { version = "0.63.0", default-features = false, features = [
+    "max-performance-safe",
+    "blocking-network-client",
+], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "1", optional = true }


### PR DESCRIPTION
The PR is pretty self-explanatory.

In one of my projects ([`cargo-unmaintained`](https://github.com/trailofbits/cargo-unmaintained)), I am seeing this Dependabot alert: https://github.com/advisories/GHSA-7w47-3wg8-547c

`cargo-unmaintained` relies on `gix` through `crates-index` only. So, I am hoping that this upgrade will cause the alert to go away.

Since this is not a RustSect advisory, I unfortunately do not know how to test that idea locally.