### PR TITLE
feature: expose dependency registry url

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -137,6 +137,7 @@ pub struct Dependency {
     package: Option<Box<SmolStr>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     kind: Option<DependencyKind>,
+    registry: SmolStr,
     #[serde(skip_serializing_if = "Option::is_none")]
     target: Option<Box<SmolStr>>,
     optional: bool,
@@ -194,6 +195,15 @@ impl Dependency {
     #[must_use]
     pub fn kind(&self) -> DependencyKind {
         self.kind.unwrap_or_default()
+    }
+
+    /// Registry URL
+    ///
+    /// Example: `https://github.com/rust-lang/crates.io-index.git`
+    #[inline]
+    #[must_use]
+    pub fn registry(&self) -> &str {
+        &self.registry
     }
 
     /// Set if dependency's crate name is different from the `name` (alias)


### PR DESCRIPTION
This commit exposes the field `registry` on the `Dependency` struct. This field is always set by `cargo`, and it's needed to properly handle dependencies when multiple registries are used.