### PR TITLE
Add MacOS to CI matrix

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         rust:
           - stable

--- a/tests/git/mod.rs
+++ b/tests/git/mod.rs
@@ -11,14 +11,24 @@ pub(crate) mod with_https {
         let mut last_time = SystemTime::now();
         let desired = 500;
         let mut count = 0;
+        let mut missing = 0;
         for c in ch.take(desired) {
             let c = c.unwrap();
             count += 1;
-            index.crate_(&c.crate_name()).unwrap();
+            if index.crate_(&c.crate_name()).is_none() {
+                eprintln!(
+                    "{} is changed but couldn't be found in the Git database",
+                    c.crate_name()
+                );
+                missing += 1
+            }
             assert!(last_time >= c.time());
             last_time = c.time();
         }
         assert_eq!(count, desired);
+        if missing != 0 {
+            eprintln!("Couldn't find {missing} crates when looking them up - strange")
+        }
     }
 
     #[test]


### PR DESCRIPTION
I've been using this platform in my last PR and everything works just as expected. Figured it would be a good idea to include this so there's some kind of signal if the platform breaks.