### PR TITLE
Fix urls with trailing slashses with paths

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -186,8 +186,7 @@ fn url_to_local_dir(url: &str, hash_kind: &HashKind) -> Result<(String, String),
     // https://index.crates.io/ it messes it up
     // as well. So we strip if it has a path
     // past the base url
-    let needs_to_strip = has_path_past_base(url);
-    if needs_to_strip {
+    if has_path_past_base(url) {
         if let Some(stripped_url) = url.strip_suffix('/') {
             url = stripped_url;
         }


### PR DESCRIPTION
- See issue in [rules_rust ](https://github.com/bazelbuild/rules_rust/issues/3310)
- Seems like @UebelAndre [PR ](https://github.com/frewsxcv/rust-crates-index/pull/184) broke custom crates repositories hashing that ended with a slash. 
- Removing slashes on urls with paths seems to have fixed the issue.  I was able to patch this through to rules rust and confirmed it work
