### PR TITLE
fix: upgrade gix for security advisory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ name = "update_and_get_most_recent_version"
 required-features = ["git-https"]
 
 [dependencies]
-gix = { version = "0.79.0", default-features = false, features = ["max-performance-safe", "blocking-network-client", "revision"], optional = true }
+gix = { version = "0.83.0", default-features = false, features = ["max-performance-safe", "blocking-network-client", "revision", "sha1"], optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 home = "0.5.4"
 http = { version = "1", optional = true }

--- a/src/git/impl_.rs
+++ b/src/git/impl_.rs
@@ -578,7 +578,7 @@ impl Iterator for CratesTreesToBlobs {
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(obj) = self.stack.pop() {
             if obj.kind.is_tree() {
-                let tree = gix::objs::TreeRef::from_bytes(&obj.data).unwrap();
+                let tree = gix::objs::TreeRef::from_bytes(&obj.data, gix::hash::Kind::Sha1).unwrap();
                 for entry in tree.entries.into_iter().rev() {
                     self.stack.push(self.repo.find_object(entry.oid).unwrap().detach());
                 }


### PR DESCRIPTION
## Why

- `gix` versions before `0.83.0` are affected by [GHSA-f26g-jm89-4g65](https://github.com/advisories/GHSA-f26g-jm89-4g65), a high-severity advisory in `gix_submodule::File::update()`.
- `crates-index` does not call the vulnerable submodule update API, but it exposes `gix` through the optional `git` feature. Updating the dependency range lets downstream users resolve a patched `gix` version and clears security tooling alerts.

## What

- Upgrade the optional `gix` dependency from `0.79.0` to `0.83.0`, the first patched version.
- Enable `gix`'s `sha1` feature explicitly, as required by the newer `gix-hash`.
- Pass `gix::hash::Kind::Sha1` when decoding tree objects to match the updated `gix` API and the crates.io git index format.

## Validation

- `cargo check --all-targets --no-default-features`
- `cargo check --all-targets --no-default-features --features git`
- `cargo test --features=git-performance,git-https --release`

## Notes

- `gix 0.83.0` declares Rust `1.82` as its own MSRV, so this may raise the effective Rust version required by consumers that enable the optional `git` feature.
